### PR TITLE
chore: test string template literal types

### DIFF
--- a/test/string-literal-types.test.ts
+++ b/test/string-literal-types.test.ts
@@ -1,0 +1,69 @@
+import { sourceToAssemblyHelper } from '../lib';
+
+// ----------------------------------------------------------------------
+test('test parsing string literal type with enum interpolation', () => {
+  const assembly = sourceToAssemblyHelper(`
+    export enum Foo {
+      BAR,
+      BAZ,
+    }
+
+    export interface UsesSTT {
+      readonly foo: \`foo - \${Foo}\`
+    }
+  `);
+
+  expect(assembly.types!['testpkg.UsesSTT']).toEqual({
+    assembly: 'testpkg',
+    datatype: true,
+    fqn: 'testpkg.UsesSTT',
+    kind: 'interface',
+    properties: [{
+      abstract: true,
+      immutable: true,
+      locationInModule: {
+        filename: 'index.ts',
+        line: 8,
+      },
+      name: 'foo',
+      type: {
+        primitive: 'string',
+      },
+    }],
+    locationInModule: { filename: 'index.ts', line: 7 },
+    name: 'UsesSTT',
+    symbolId: 'index:UsesSTT',
+  });
+});
+
+// ----------------------------------------------------------------------
+test('test parsing string literal type with number interpolation', () => {
+  debugger;
+  const assembly = sourceToAssemblyHelper(`
+    export interface UsesSTT {
+      readonly foo: \`foo - \${number}\`
+    }
+  `);
+
+  expect(assembly.types!['testpkg.UsesSTT']).toEqual({
+    assembly: 'testpkg',
+    datatype: true,
+    fqn: 'testpkg.UsesSTT',
+    kind: 'interface',
+    properties: [{
+      abstract: true,
+      immutable: true,
+      locationInModule: {
+        filename: 'index.ts',
+        line: 3,
+      },
+      name: 'foo',
+      type: {
+        primitive: 'string',
+      },
+    }],
+    locationInModule: { filename: 'index.ts', line: 2 },
+    name: 'UsesSTT',
+    symbolId: 'index:UsesSTT',
+  });
+});


### PR DESCRIPTION
Verify that they are propertly represented as:

```js
{ primitiveType: "string" }
```



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0