### PR TITLE
feat: `noImplicitOverride`, `noUncheckedIndexedAccess`, `noPropertyAccessFromIndexSignature`

### DIFF
--- a/fixtures/jsii-calc/lib/compliance.ts
+++ b/fixtures/jsii-calc/lib/compliance.ts
@@ -279,7 +279,7 @@ export class ObjectRefsInCollections {
   public sumFromMap(values: { [key: string]: NumericValue }) {
     let sum = 0;
     for (const key of Object.keys(values)) {
-      sum += values[key].value;
+      sum += values[key]!.value;
     }
     return sum;
   }
@@ -682,7 +682,7 @@ export class VariadicInvoker {
 
   public asArray(...values: number[]): number[] {
     const [first, ...rest] = values;
-    return this.method.asArray(first, ...rest);
+    return this.method.asArray(first!, ...rest);
   }
 }
 
@@ -1591,7 +1591,7 @@ export class JsiiAgent {
    * Returns the value of the JSII_AGENT environment variable.
    */
   public static get value(): string | undefined {
-    return process.env.JSII_AGENT;
+    return process.env['JSII_AGENT'];
   }
 }
 
@@ -1795,14 +1795,14 @@ export class ImplementsInterfaceWithInternal implements IInterfaceWithInternal {
 
 export class ImplementsInterfaceWithInternalSubclass extends ImplementsInterfaceWithInternal {
   /** @internal */
-  public _alsoHidden() {
+  public override _alsoHidden() {
     return;
   }
 
   /**
    * @internal
    */
-  public _propertiesToo?: string;
+  public override _propertiesToo?: string;
 }
 
 //
@@ -2242,7 +2242,7 @@ export class SupportsNiceJavaBuilder extends SupportsNiceJavaBuilderWithRequired
    * @param rest       a variadic continuation
    */
   public constructor(
-    public readonly id: number,
+    public override readonly id: number,
     defaultBar = 1337,
     props?: SupportsNiceJavaBuilderProps,
     ...rest: string[]
@@ -2936,11 +2936,11 @@ export class StaticHelloParent {
   }
 }
 export class StaticHelloChild extends StaticHelloParent {
-  public static get property(): number {
+  public static override get property(): number {
     return 42;
   }
 
-  public static method(): void {
+  public static override method(): void {
     /* An ES6 Override */
   }
 

--- a/fixtures/jsii-calc/lib/erasures.ts
+++ b/fixtures/jsii-calc/lib/erasures.ts
@@ -22,7 +22,7 @@ class JSII417PrivateBase extends JSII417PublicBaseOfBase {
   }
 }
 export class JSII417Derived extends JSII417PrivateBase {
-  public bar(): void {
+  public override bar(): void {
     return super.bar();
   }
   public baz(): void {

--- a/fixtures/jsii-calc/package.json
+++ b/fixtures/jsii-calc/package.json
@@ -68,6 +68,9 @@
       }
     },
     "tsc": {
+      "noImplicitOverride": true,
+      "noPropertyAccessFromIndexSignature": true,
+      "noUncheckedIndexedAccess": true,
       "types": [
         "node"
       ]

--- a/fixtures/jsii-calc/test/test.calc.ts
+++ b/fixtures/jsii-calc/test/test.calc.ts
@@ -79,8 +79,8 @@ sum.parts = [
   new Multiply(new calcLib.Number(2), new calcLib.Number(3)),
 ];
 assert.equal(10 + 5 + 2 * 3, sum.value);
-assert.equal(sum.parts[0].value, 5);
-assert.equal(sum.parts[2].value, 6);
+assert.equal(sum.parts[0]!.value, 5);
+assert.equal(sum.parts[2]!.value, 6);
 assert.equal(sum.toString(), '(((0 + 5) + 10) + (2 * 3))');
 
 //
@@ -91,9 +91,9 @@ const calc2 = new Calculator(); // Initializer overload (props is optional)
 calc2.add(10);
 calc2.add(20);
 calc2.mul(2);
-assert.equal(calc2.operationsMap.add.length, 2);
-assert.equal(calc2.operationsMap.mul.length, 1);
-assert.equal(calc2.operationsMap.add[1].value, 30);
+assert.equal(calc2.operationsMap['add']!.length, 2);
+assert.equal(calc2.operationsMap['mul']!.length, 1);
+assert.equal(calc2.operationsMap['add']?.[1]!.value, 30);
 
 //
 // Initializer overloads

--- a/src/project-info.ts
+++ b/src/project-info.ts
@@ -25,6 +25,9 @@ export type TSCompilerOptions = Partial<
     | 'paths'
     // Style preferences
     | 'forceConsistentCasingInFileNames'
+    | 'noImplicitOverride'
+    | 'noPropertyAccessFromIndexSignature'
+    | 'noUncheckedIndexedAccess'
     // Source map preferences
     | 'declarationMap'
     | 'inlineSourceMap'
@@ -195,6 +198,9 @@ export function loadProjectInfo(projectRoot: string): ProjectInfoResult {
       baseUrl: pkg.jsii?.tsc?.baseUrl,
       paths: pkg.jsii?.tsc?.paths,
       forceConsistentCasingInFileNames: pkg.jsii?.tsc?.forceConsistentCasingInFileNames,
+      noImplicitOverride: pkg.jsii?.tsc?.noImplicitOverride,
+      noPropertyAccessFromIndexSignature: pkg.jsii?.tsc?.noPropertyAccessFromIndexSignature,
+      noUncheckedIndexedAccess: pkg.jsii?.tsc?.noUncheckedIndexedAccess,
       ..._sourceMapPreferences(pkg.jsii?.tsc),
       types: pkg.jsii?.tsc?.types,
     },


### PR DESCRIPTION
Adds support for configuring `noImplicitOverride`, `noUncheckedIndexedAccess`, and `noPropertyAccessFromIndexSignature` via the `jsii` stanza in `package.json`, and use those features in the `jsii-calc` fixture to demonstrate they work.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0