### PR TITLE
feat: automatic down-leveling of declarations files

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -85,6 +85,11 @@
       "type": "build"
     },
     {
+      "name": "jsii-1.x",
+      "version": "npm:jsii@1",
+      "type": "build"
+    },
+    {
       "name": "lockfile",
       "type": "build"
     },
@@ -124,6 +129,10 @@
     {
       "name": "chalk",
       "version": "^4",
+      "type": "runtime"
+    },
+    {
+      "name": "downlevel-dts",
       "type": "runtime"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -194,19 +194,19 @@
           "exec": "yarn upgrade npm-check-updates"
         },
         {
-          "exec": "npm-check-updates --dep dev --upgrade --target=minor"
+          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='jsii-1.x'"
         },
         {
-          "exec": "npm-check-updates --dep optional --upgrade --target=minor"
+          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='jsii-1.x'"
         },
         {
-          "exec": "npm-check-updates --dep peer --upgrade --target=minor"
+          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='jsii-1.x'"
         },
         {
-          "exec": "npm-check-updates --dep prod --upgrade --target=minor"
+          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='jsii-1.x'"
         },
         {
-          "exec": "npm-check-updates --dep bundle --upgrade --target=minor"
+          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='jsii-1.x'"
         },
         {
           "exec": "yarn install --check-files"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -62,7 +62,14 @@ const project = new typescript.TypeScriptProject({
     configFilePath: 'jest.config.json',
     jestConfig: {
       moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
-      watchPathIgnorePatterns: ['<rootDir>/fixtures/'],
+      watchPathIgnorePatterns: [
+        // NB: Those are regexes...
+        '<rootDir>/fixtures/\\..*',
+        '<rootDir>/fixtures/node_modules',
+        '<rootDir>/fixtures/.*\\.d\\.ts',
+        '<rootDir>/fixtures/.*\\.js',
+        '<rootDir>/fixtures/.*\\.map',
+      ],
     },
     junitReporting: false,
   },
@@ -144,6 +151,7 @@ project.addDeps(
   '@jsii/spec',
   'case',
   'chalk@^4',
+  'downlevel-dts',
   'fast-deep-equal',
   'log4js',
   'semver',
@@ -164,6 +172,7 @@ project.addDevDeps(
   'all-contributors-cli',
   'clone',
   'eslint-plugin-unicorn',
+  'jsii-1.x@npm:jsii@1',
   'lockfile',
 );
 

--- a/fixtures/@scope/jsii-calc-base/lib/index.ts
+++ b/fixtures/@scope/jsii-calc-base/lib/index.ts
@@ -1,6 +1,9 @@
+// NOTE: Intentionally mixing type imports with value imports. This syntax form
+//       was added in TypeScript 4.5, and requires declarations down-leveling to
+//       be supported by TypeScript 3.9 / jsii 1.x.
 import {
-  IVeryBaseInterface,
-  VeryBaseProps,
+  type IVeryBaseInterface,
+  type VeryBaseProps,
   StaticConsumer as StaticConsumerBase,
 } from '@scope/jsii-calc-base-of-base';
 

--- a/fixtures/@scope/jsii-calc-base/package.json
+++ b/fixtures/@scope/jsii-calc-base/package.json
@@ -23,6 +23,13 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "typesVersions": {
+    "<=3.9": {
+      "*": [
+        ".types-compat/ts3.9/*"
+      ]
+    }
+  },
   "dependencies": {
     "@scope/jsii-calc-base-of-base": "^2.1.1"
   },

--- a/fixtures/jsii-calc/lib/duplicate-inherited-prop.ts
+++ b/fixtures/jsii-calc/lib/duplicate-inherited-prop.ts
@@ -1,4 +1,4 @@
-import { DiamondLeft, DiamondRight } from '@scope/jsii-calc-lib';
+import { DiamondLeft, type DiamondRight } from '@scope/jsii-calc-lib';
 
 // This is half of the contraption, the rest is in @scope/jsii-calc-lib.
 //

--- a/fixtures/jsii-calc/package.json
+++ b/fixtures/jsii-calc/package.json
@@ -32,6 +32,13 @@
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "typesVersions": {
+    "<=3.9": {
+      "*": [
+        ".types-compat/ts3.9/*"
+      ]
+    }
+  },
   "dependencies": {
     "@fixtures/jsii-calc-bundled": "file:../@fixtures/jsii-calc-bundled",
     "@scope/jsii-calc-base": "^0.0.0",

--- a/jest.config.json
+++ b/jest.config.json
@@ -6,7 +6,11 @@
     "json"
   ],
   "watchPathIgnorePatterns": [
-    "<rootDir>/fixtures/"
+    "<rootDir>/fixtures/\\..*",
+    "<rootDir>/fixtures/node_modules",
+    "<rootDir>/fixtures/.*\\.d\\.ts",
+    "<rootDir>/fixtures/.*\\.js",
+    "<rootDir>/fixtures/.*\\.map"
   ],
   "testMatch": [
     "<rootDir>/src/**/__tests__/**/*.ts?(x)",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-unicorn": "^45.0.2",
     "jest": "^29.4.2",
+    "jsii-1.x": "npm:jsii@1",
     "lockfile": "^1.0.4",
     "npm-check-updates": "^16",
     "prettier": "^2.8.4",
@@ -59,10 +60,11 @@
     "ts-node": "^10.9.1"
   },
   "dependencies": {
-    "@jsii/check-node": "^1.75.0",
+    "@jsii/check-node": "1.75.0",
     "@jsii/spec": "^1.75.0",
     "case": "^1.6.3",
     "chalk": "^4",
+    "downlevel-dts": "^0.11.0",
     "fast-deep-equal": "^3.1.3",
     "log4js": "^6.7.1",
     "semver": "^7.3.8",

--- a/src/ambient/downlevel-dts.ts
+++ b/src/ambient/downlevel-dts.ts
@@ -1,0 +1,15 @@
+/** Hand-written declaration for the downlevel-dts module */
+declare module 'downlevel-dts' {
+  import { SemVer } from 'semver';
+
+  /**
+   * Rewrite .d.ts files created by any version of TypeScript so that they work
+   * with TypeScript 3.4 or later. It does this by converting code with new
+   * features into code that uses equivalent old features.
+   *
+   * @param src           the directory containing the original .d.ts files
+   * @param target        the directory in which to place re-written files
+   * @param targetVersion the target TypeScript version compatibility
+   */
+  export function main(src: string, target: string, targetVersion: string | SemVer): void;
+}

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -190,7 +190,7 @@ export class Assembler implements Emitter {
       version: this.projectInfo.version,
       description: this.projectInfo.description ?? this.projectInfo.name,
       license: this.projectInfo.license,
-      keywords: this.projectInfo.keywords,
+      keywords: this.projectInfo.keywords && Array.from(this.projectInfo.keywords),
       homepage: this.projectInfo.homepage ?? this.projectInfo.repository.url,
       author: this.projectInfo.author,
       contributors: this.projectInfo.contributors && [...this.projectInfo.contributors],

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -6,6 +6,7 @@ import * as ts from 'typescript';
 
 import { Assembler } from './assembler';
 import * as Case from './case';
+import { emitDownleveledDeclarations } from './downlevel-dts';
 import { Emitter } from './emitter';
 import { JsiiDiagnostic } from './jsii-diagnostic';
 import { ProjectInfo } from './project-info';
@@ -269,6 +270,10 @@ export class Compiler implements Emitter {
     if (!hasErrors && (emit.emitSkipped || this.diagsHaveAbortableErrors(emit.diagnostics))) {
       hasErrors = true;
       LOG.error('Compilation errors prevented the JSII assembly from being created');
+    }
+
+    if (!hasErrors) {
+      emitDownleveledDeclarations(this.options.projectInfo);
     }
 
     // Some extra validation on the config.

--- a/src/downlevel-dts.ts
+++ b/src/downlevel-dts.ts
@@ -1,0 +1,190 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join, relative } from 'node:path';
+import { main as downlevel } from 'downlevel-dts';
+import * as log4js from 'log4js';
+import { SemVer } from 'semver';
+import * as ts from 'typescript';
+import type { PackageJson, ProjectInfo } from './project-info';
+import type { Mutable } from './utils';
+
+const LOG = log4js.getLogger('jsii/compiler');
+
+const TS_VERSION = new SemVer(`${ts.versionMajorMinor}.0`);
+
+/**
+ * Declares what versions of the TypeScript language will be supported by the
+ * declarations files (and `typesVersions` entries) produced by this compiler
+ * release.
+ *
+ * This should contain only `major.minor` specifiers, similar to the value of
+ * the `ts.versionMajorMinor` property, and must be sorted in ascending version
+ * order, as this dictates the order of entries in the `typesVersions` redirects
+ * which has a direct impact on resolution (first match wins), and we don't want
+ * to have to perform a sort pass on this list.
+ */
+const DOWNLEVEL_BREAKPOINTS: readonly SemVer[] = ['3.9'].map((ver) => new SemVer(`${ver}.0`));
+
+/**
+ * Produces down-leveled declaration files to ensure compatibility with previous
+ * compiler releases (macthing TypeScript's `major.minor` versioning scheme).
+ * This is necessary in order to ensure a package change compiler release lines
+ * does not force all it's consumers to do the same (and vice-versa).
+ *
+ * @returns the `typesVersions` object that should be recorded in `package.json`
+ */
+export function emitDownleveledDeclarations({ packageJson, projectRoot, tsc }: ProjectInfo) {
+  const rewrites = new Map<`${number}.${number}`, Map<string, string>>();
+
+  for (const breakpoint of DOWNLEVEL_BREAKPOINTS) {
+    if (TS_VERSION.compare(breakpoint) <= 0) {
+      // This TypeScript release is older or same as the breakpoint, so no need
+      // for down-leveling here.
+      continue;
+    }
+
+    const rewriteSet = new Map<string, string>();
+    let needed = false;
+
+    // We'll emit down-leveled declarations in a temporary directory...
+    const workdir = mkdtempSync(join(tmpdir(), `downlevel-dts-${breakpoint}-${basename(projectRoot)}-`));
+    try {
+      downlevel(projectRoot, workdir, breakpoint);
+      for (const dts of walkDirectory(workdir)) {
+        const original = readFileSync(join(projectRoot, dts), 'utf-8');
+        const downleveled = readFileSync(join(workdir, dts), 'utf-8');
+        needed ||= !equalWithNormalizedLineTerminator(original, downleveled);
+        rewriteSet.set(dts, downleveled);
+      }
+
+      // If none of the declarations files changed during the down-level, then
+      // we don't need to actually write it out & cause a redirect. This would
+      // be wasteful. Most codebases won't incur any rewrite at all, since the
+      // declarations files only reference "visible" members, and `jsii`
+      // actually does not allow most of the unsupported syntaxes to be used
+      // anyway.
+      if (needed) {
+        rewrites.set(`${breakpoint.major}.${breakpoint.minor}`, rewriteSet);
+      }
+    } finally {
+      // Clean up after outselves...
+      rmSync(workdir, { force: true, recursive: true });
+    }
+  }
+
+  let typesVersions: Mutable<PackageJson['typesVersions']>;
+
+  const typesCompat = '.types-compat';
+  for (const [version, rewriteSet] of rewrites) {
+    const versionSuffix = `ts${version}`;
+    const compatDir = join(projectRoot, ...(tsc?.outDir != null ? [tsc?.outDir] : []), typesCompat, versionSuffix);
+    if (!existsSync(compatDir)) {
+      mkdirSync(compatDir, { recursive: true });
+      // Make sure all of this is gitignored, out of courtesy...
+      writeFileSync(join(projectRoot, typesCompat, '.gitignore'), '*\n', 'utf-8');
+    }
+
+    for (const [dts, downleveled] of rewriteSet) {
+      const rewritten = join(compatDir, dts);
+      // Make sure the parent directory exists (dts might be nested)
+      mkdirSync(dirname(rewritten), { recursive: true });
+      // Write the re-written declarations file there...
+      writeFileSync(rewritten, downleveled, 'utf-8');
+    }
+
+    // Register the type redirect in the typesVersions configuration
+    typesVersions ??= {};
+    const from = [...(tsc?.outDir != null ? [tsc?.outDir] : []), '*'].join('/');
+    const to = [...(tsc?.outDir != null ? [tsc?.outDir] : []), typesCompat, versionSuffix, '*'].join('/');
+    typesVersions[`<=${version}`] = { [from]: [to] };
+  }
+
+  // Compare JSON stringifications, as the order of keys is important here...
+  if (JSON.stringify(packageJson.typesVersions) === JSON.stringify(typesVersions)) {
+    // The existing configuration matches the new one. We're done here.
+    return;
+  }
+
+  LOG.info('The required `typesVersions` configuration has changed. Updating "package.json" accordingly...');
+
+  // Prepare the new contents of `PackageJson`.
+  const newPackageJson = Object.entries(packageJson).reduce((obj, [key, value]) => {
+    // NB: "as any" below are required becuase we must ignore `readonly` attributes from the source.
+    if (key === 'typesVersions') {
+      if (typesVersions != null) {
+        obj[key] = typesVersions as any;
+      }
+    } else {
+      obj[key] = value as any;
+      // If there isn't currently a `typesVersions` entry, but there is a `types` entry,
+      // we'll insert `typesVersions` right after `types`.
+      if (key === 'types' && typesVersions != null && !('typesVersions' in packageJson)) {
+        obj.typesVersions = typesVersions as any;
+      }
+    }
+    return obj;
+  }, {} as Mutable<PackageJson>);
+  // If there was neither `types` nor `typesVersions` in the original `package.json`, we'll
+  // add `typesVersions` at the end of it.
+  if (!('typesVersions' in newPackageJson)) {
+    newPackageJson.typesVersions = typesVersions as any;
+  }
+
+  const packageJsonFile = join(projectRoot, 'package.json');
+
+  // We try "hard" to preserve the existing indent in the `package.json` file when updating it.
+  const [, indent] = readFileSync(packageJsonFile, 'utf-8').match(/^(\s*)"/m) ?? [null, 2];
+
+  writeFileSync(packageJsonFile, `${JSON.stringify(newPackageJson, undefined, indent)}\n`, 'utf-8');
+}
+
+/**
+ * Compares two strings ignoring new line differences. This is necessary because
+ * `downlevel-dts` may use a different line-ending convention (at time of
+ * writing, it always uses CRLF) than what `jsii` itself emits, but that should
+ * not affect the comparison of declarations files.
+ *
+ * @param left the first string.
+ * @param right the second string.
+ *
+ * @returns `true` if `left` and `right` contain the same text, modulo line
+ *          terminator tokens.
+ */
+function equalWithNormalizedLineTerminator(left: string, right: string): boolean {
+  // ECMA262 12.3: https://tc39.es/ecma262/#sec-line-terminators
+  const JS_LINE_TERMINATOR_REGEX = /(\n|\r\n?|\u{2028}|\u{2029})/gmu;
+
+  left = left.replace(JS_LINE_TERMINATOR_REGEX, '\n').trim();
+  right = right.replace(JS_LINE_TERMINATOR_REGEX, '\n').trim();
+
+  return left === right;
+}
+
+/**
+ * Recursively traverse the provided directory and yield the relative (to the
+ * specified `root`) paths of all the `.d.ts` files found there.
+ *
+ * @param dir the directory to be walked.
+ * @param root the root to which paths should be relative.
+ */
+function* walkDirectory(dir: string, root: string = dir): Generator<string, void, void> {
+  for (const file of readdirSync(dir)) {
+    const filePath = join(dir, file);
+    if (statSync(filePath).isDirectory()) {
+      // This is a directory, recurse down...
+      yield* walkDirectory(filePath, root);
+    } else if (file.toLowerCase().endsWith('.d.ts')) {
+      // This is a declaration file, yield it...
+      yield relative(root, filePath);
+    }
+  }
+}

--- a/src/project-info.ts
+++ b/src/project-info.ts
@@ -37,7 +37,7 @@ export type TSCompilerOptions = Partial<
 
 export interface ProjectInfo {
   readonly projectRoot: string;
-  readonly packageJson: any;
+  readonly packageJson: PackageJson;
 
   readonly name: string;
   readonly version: string;
@@ -50,7 +50,7 @@ export interface ProjectInfo {
     readonly url: string;
     readonly directory?: string;
   };
-  readonly keywords?: string[];
+  readonly keywords?: readonly string[];
 
   readonly main: string;
   readonly types: string;
@@ -60,19 +60,67 @@ export interface ProjectInfo {
   readonly dependencyClosure: readonly spec.Assembly[];
   readonly bundleDependencies?: { readonly [name: string]: string };
   readonly targets: spec.AssemblyTargets;
-  readonly metadata?: { [key: string]: any };
+  readonly metadata?: { readonly [key: string]: any };
   readonly jsiiVersionFormat: 'short' | 'full';
   readonly diagnostics?: { readonly [code: string]: ts.DiagnosticCategory };
   readonly description?: string;
   readonly homepage?: string;
   readonly contributors?: readonly spec.Person[];
-  readonly excludeTypescript: string[];
+  readonly excludeTypescript: readonly string[];
   readonly projectReferences?: boolean;
   readonly tsc?: TSCompilerOptions;
   readonly bin?: { readonly [name: string]: string };
   readonly exports?: {
     readonly [name: string]: string | { readonly [name: string]: string };
   };
+}
+
+export interface PackageJson {
+  readonly description?: string;
+  readonly homepage?: string;
+  readonly name?: string;
+  readonly version?: string;
+  readonly keywords?: readonly string[];
+  readonly license?: string;
+  readonly private?: boolean;
+
+  readonly exports?: { readonly [path: string]: string | { readonly [name: string]: string } };
+  readonly main?: string;
+  readonly types?: string;
+  /**
+   * @example { "<4.0": { "*": ["ts3.9/*"] } }
+   * @example { "<4.0": { "index.d.ts": ["index.ts3-9.d.ts"] } }
+   */
+  readonly typesVersions?: {
+    readonly [versionRange: string]: { readonly [pattern: string]: readonly string[] };
+  };
+
+  readonly bin?: { readonly [name: string]: string };
+
+  readonly stability?: string;
+  readonly deprecated?: string;
+
+  readonly dependencies?: { readonly [name: string]: string };
+  readonly devDependencies?: { readonly [name: string]: string };
+  readonly peerDependencies?: { readonly [name: string]: string };
+
+  readonly bundleDependencies?: readonly string[];
+  readonly bundledDependencies?: readonly string[];
+
+  readonly jsii?: {
+    readonly diagnostics?: { readonly [id: string]: 'error' | 'warning' | 'suggestion' | 'message' };
+    readonly metadata?: { readonly [key: string]: unknown };
+    readonly targets?: { readonly [name: string]: unknown };
+    readonly versionFormat?: 'short' | 'full';
+
+    readonly excludeTypescript?: readonly string[];
+    readonly projectReferences?: boolean;
+    readonly tsc?: TSCompilerOptions;
+
+    readonly [key: string]: unknown;
+  };
+
+  readonly [key: string]: unknown;
 }
 
 export interface ProjectInfoResult {
@@ -82,8 +130,7 @@ export interface ProjectInfoResult {
 
 export function loadProjectInfo(projectRoot: string): ProjectInfoResult {
   const packageJsonPath = path.join(projectRoot, 'package.json');
-  // eslint-disable-next-line @typescript-eslint/no-var-requires,@typescript-eslint/no-require-imports
-  const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+  const pkg: PackageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
 
   const diagnostics: ts.Diagnostic[] = [];
 
@@ -152,7 +199,7 @@ export function loadProjectInfo(projectRoot: string): ProjectInfoResult {
     pkg.jsii?.metadata,
   );
 
-  const projectInfo = {
+  const projectInfo: ProjectInfo = {
     projectRoot,
     packageJson: pkg,
 
@@ -179,7 +226,7 @@ export function loadProjectInfo(projectRoot: string): ProjectInfoResult {
       js: { npm: pkg.name },
     },
     metadata,
-    jsiiVersionFormat: _validateVersionFormat(pkg.jsii.versionFormat ?? 'full'),
+    jsiiVersionFormat: _validateVersionFormat(pkg.jsii?.versionFormat ?? 'full'),
 
     description: pkg.description,
     homepage: pkg.homepage,
@@ -334,7 +381,7 @@ class DependencyResolver {
   }
 }
 
-function _required<T>(value: T, message: string): T {
+function _required<T>(value: T | undefined, message: string): T {
   if (value == null) {
     throw new Error(message);
   }
@@ -387,7 +434,12 @@ function _tryResolveAssembly(mod: string, localPackage: string | undefined, sear
   }
 }
 
-function _validateLicense(id: string): string {
+function _validateLicense(id: string | undefined): string {
+  if (id == null) {
+    throw new Error(
+      'No "license" was specified in "package.json", see valid license identifiers at https://spdx.org/licenses/',
+    );
+  }
   if (id === 'UNLICENSED') {
     return id;
   }
@@ -480,7 +532,7 @@ function mergeMetadata(
 
 function _loadDiagnostics(entries?: { [key: string]: string }):
   | {
-      [key: string]: ts.DiagnosticCategory;
+      readonly [key: string]: ts.DiagnosticCategory;
     }
   | undefined {
   if (entries === undefined || Object.keys(entries).length === 0) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -220,3 +220,8 @@ const ANSI_REGEX =
 export function stripAnsi(x: string): string {
   return x.replace(ANSI_REGEX, '');
 }
+
+/**
+ * Maps the provided type to stip all `readonly` modifiers from its properties.
+ */
+export type Mutable<T> = { -readonly [K in keyof T]: Mutable<T[K]> };

--- a/test/__snapshots__/integration.test.ts.snap
+++ b/test/__snapshots__/integration.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`integration: @scope/jsii-calc-base 1`] = `
+exports[`integration test: @scope/jsii-calc-base 1`] = `
 {
   "author": {
     "name": "Amazon Web Services",
@@ -100,7 +100,7 @@ exports[`integration: @scope/jsii-calc-base 1`] = `
       "kind": "class",
       "locationInModule": {
         "filename": "lib/index.ts",
-        "line": 10,
+        "line": 13,
       },
       "methods": [
         {
@@ -109,7 +109,7 @@ exports[`integration: @scope/jsii-calc-base 1`] = `
           },
           "locationInModule": {
             "filename": "lib/index.ts",
-            "line": 14,
+            "line": 17,
           },
           "name": "typeName",
           "returns": {
@@ -132,7 +132,7 @@ exports[`integration: @scope/jsii-calc-base 1`] = `
       "kind": "interface",
       "locationInModule": {
         "filename": "lib/index.ts",
-        "line": 19,
+        "line": 22,
       },
       "name": "BaseProps",
       "properties": [
@@ -141,7 +141,7 @@ exports[`integration: @scope/jsii-calc-base 1`] = `
           "immutable": true,
           "locationInModule": {
             "filename": "lib/index.ts",
-            "line": 20,
+            "line": 23,
           },
           "name": "bar",
           "type": {
@@ -160,14 +160,14 @@ exports[`integration: @scope/jsii-calc-base 1`] = `
       "kind": "interface",
       "locationInModule": {
         "filename": "lib/index.ts",
-        "line": 23,
+        "line": 26,
       },
       "methods": [
         {
           "abstract": true,
           "locationInModule": {
             "filename": "lib/index.ts",
-            "line": 24,
+            "line": 27,
           },
           "name": "bar",
         },
@@ -185,13 +185,13 @@ exports[`integration: @scope/jsii-calc-base 1`] = `
       "kind": "class",
       "locationInModule": {
         "filename": "lib/index.ts",
-        "line": 30,
+        "line": 33,
       },
       "methods": [
         {
           "locationInModule": {
             "filename": "lib/index.ts",
-            "line": 31,
+            "line": 34,
           },
           "name": "consume",
           "parameters": [
@@ -215,7 +215,7 @@ exports[`integration: @scope/jsii-calc-base 1`] = `
 }
 `;
 
-exports[`integration: @scope/jsii-calc-base-of-base 1`] = `
+exports[`integration test: @scope/jsii-calc-base-of-base 1`] = `
 {
   "author": {
     "name": "Amazon Web Services",
@@ -388,7 +388,7 @@ exports[`integration: @scope/jsii-calc-base-of-base 1`] = `
 }
 `;
 
-exports[`integration: @scope/jsii-calc-lib 1`] = `
+exports[`integration test: @scope/jsii-calc-lib 1`] = `
 {
   "author": {
     "name": "Amazon Web Services",
@@ -1425,7 +1425,7 @@ far enough up the tree.",
 }
 `;
 
-exports[`integration: jsii-calc 1`] = `
+exports[`integration test: jsii-calc 1`] = `
 {
   "author": {
     "name": "Amazon Web Services",
@@ -20369,5 +20369,53 @@ library, regardless of whether they were explicitly referenced or not.",
     },
   },
   "version": "3.20.120",
+}
+`;
+
+exports[`v1 compatibility check: test output assembly 1`] = `
+{
+  "author": {
+    "name": "John Doe",
+    "roles": [
+      "author",
+    ],
+  },
+  "description": "testpkg",
+  "fingerprint": Any<String>,
+  "homepage": "https://github.com/aws/jsii.git",
+  "jsiiVersion": Any<String>,
+  "license": "Apache-2.0",
+  "metadata": {
+    "jsii": {
+      "pacmak": {
+        "hasDefaultInterfaces": true,
+      },
+    },
+  },
+  "name": "testpkg",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aws/jsii.git",
+  },
+  "schema": "jsii/0.10.0",
+  "targets": {
+    "js": {
+      "npm": "testpkg",
+    },
+  },
+  "types": {
+    "testpkg.SomeClass": {
+      "assembly": "testpkg",
+      "fqn": "testpkg.SomeClass",
+      "kind": "class",
+      "locationInModule": {
+        "filename": "index.ts",
+        "line": 3,
+      },
+      "name": "SomeClass",
+      "symbolId": "index:SomeClass",
+    },
+  },
+  "version": "0.0.1",
 }
 `;

--- a/test/compiler.test.ts
+++ b/test/compiler.test.ts
@@ -211,7 +211,7 @@ describe(Compiler, () => {
 function _makeProjectInfo(sourceDir: string, types: string): ProjectInfo {
   return {
     projectRoot: sourceDir,
-    packageJson: undefined,
+    packageJson: {},
     types,
     main: types.replace(/(?:\.d)?\.ts(x?)/, '.js$1'),
     name: 'jsii', // That's what package.json would tell if we look up...

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,10 +1,15 @@
 import { existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { lock, unlock } from 'lockfile';
+import { DiagnosticCategory } from 'typescript';
 import { Compiler } from '../src/compiler';
 import { loadProjectInfo } from '../src/project-info';
+import { formatDiagnostic } from '../src/utils';
 
-const FIXTURES_ROOT = resolve(__dirname, '..', 'fixtures');
+/**
+ * The root directory in which fixtures are located.
+ */
+export const FIXTURES_ROOT = resolve(__dirname, '..', 'fixtures');
 
 /**
  * Compiles the specified fixture module.
@@ -31,6 +36,12 @@ export function compile(_lock: Lock, name: string, addDeprecationWarnings: boole
   });
 
   const result = compiler.emit();
+  expect(
+    result.diagnostics
+      .filter((diag) => diag.category === DiagnosticCategory.Error)
+      .map((diag) => formatDiagnostic(diag, projectRoot))
+      .join('\n'),
+  ).toEqual('');
   expect(result).toHaveProperty('emitSkipped', false);
 
   return projectRoot;

--- a/test/negatives.test.ts
+++ b/test/negatives.test.ts
@@ -95,7 +95,7 @@ function _makeProjectInfo(types: string): ProjectInfo {
   const outDir = '.build';
   return {
     projectRoot: SOURCE_DIR,
-    packageJson: undefined,
+    packageJson: {},
     types: path.join(outDir, types.replace(/\.d\.ts(x?)/, '.d.ts$1')),
     main: path.join(outDir, types.replace(/(?:\.d)?\.ts(x?)/, '.js$1')),
     name: 'jsii', // That's what package.json would tell if we look up...

--- a/yarn.lock
+++ b/yarn.lock
@@ -644,7 +644,7 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@jsii/check-node@^1.75.0":
+"@jsii/check-node@1.75.0":
   version "1.75.0"
   resolved "https://registry.yarnpkg.com/@jsii/check-node/-/check-node-1.75.0.tgz#1cfc2ab5b461c1e80d9a4c18a6e351a9a13287ce"
   integrity sha512-ODorfPJwN0920DJrZ/R/G3x0UHgtuhz9y10s6Xox1BDobVXOQpfUl3XEQjrTrSE7kiCt2FxZvazT4xu1MU0y6Q==
@@ -2025,6 +2025,15 @@ dot-prop@^6.0.1:
   dependencies:
     is-obj "^2.0.0"
 
+downlevel-dts@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/downlevel-dts/-/downlevel-dts-0.11.0.tgz#514a2d723009c5845730c1db6c994484c596ed9c"
+  integrity sha512-vo835pntK7kzYStk7xUHDifiYJvXxVhUapt85uk2AI94gUUAQX9HNRtrcMHNSc3YHJUEHGbYIGsM99uIbgAtxw==
+  dependencies:
+    semver "^7.3.2"
+    shelljs "^0.8.3"
+    typescript next
+
 eastasianwidth@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
@@ -2537,6 +2546,15 @@ fp-and-or@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/fp-and-or/-/fp-and-or-0.1.3.tgz#e6fba83872a5853a56b3ebdf8d3167f5dfca1882"
   integrity sha512-wJaE62fLaB3jCYvY2ZHjZvmKK2iiLiiehX38rz5QZxtdN8fVPJDeZUiVvJrHStdTc+23LHlyZuSEKgFc0pxi2g==
+
+fs-extra@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
+  integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-extra@^8.1.0:
   version "8.1.0"
@@ -3716,6 +3734,25 @@ jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==
+
+"jsii-1.x@npm:jsii@1":
+  version "1.75.0"
+  resolved "https://registry.yarnpkg.com/jsii/-/jsii-1.75.0.tgz#e18fc8cb3ad985da93fb1513fc1e4d8ca191ff98"
+  integrity sha512-9CWt2IQcM6v5k4XZnaSnsK9epfIJfHWMyB69uOjITZpwYjF0CDzLrh/a8l1RyC3COSpp1K1yTjaebHEivyVr4Q==
+  dependencies:
+    "@jsii/check-node" "1.75.0"
+    "@jsii/spec" "^1.75.0"
+    case "^1.6.3"
+    chalk "^4"
+    fast-deep-equal "^3.1.3"
+    fs-extra "^10.1.0"
+    log4js "^6.7.1"
+    semver "^7.3.8"
+    semver-intersect "^1.4.0"
+    sort-json "^2.0.1"
+    spdx-license-list "^6.6.0"
+    typescript "~3.9.10"
+    yargs "^16.2.0"
 
 json-buffer@3.0.1:
   version "3.0.1"
@@ -4974,7 +5011,7 @@ semver-utils@^1.1.4:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@7.x, semver@^7.0.0, semver@^7.1.1, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8:
+semver@7.x, semver@^7.0.0, semver@^7.1.1, semver@^7.3.2, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8:
   version "7.3.8"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
@@ -5003,7 +5040,7 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shelljs@^0.8.5:
+shelljs@^0.8.3, shelljs@^0.8.5:
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
   integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
@@ -5505,6 +5542,16 @@ typedarray-to-buffer@^3.1.5:
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
   dependencies:
     is-typedarray "^1.0.0"
+
+typescript@next:
+  version "5.0.0-dev.20230215"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.0-dev.20230215.tgz#dd07b5d766e625052d92cdcc50703e33ecfdcd53"
+  integrity sha512-rbuBEuyaLltNQkRsBCxysSHGGEaizuGaVEMO+8bBmTXQRSzITTl1WOg2UFXr9p0pwz8l0KJtOem8MggaGz1/XA==
+
+typescript@~3.9.10:
+  version "3.9.10"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
+  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
 typescript@~4.9.5:
   version "4.9.5"


### PR DESCRIPTION
In order to ensure compatibility of output `.d.ts` files with previous compiler release lines, we automatically emit down-leveled `.d.ts` files and insert `typesVersions` settings in `package.json` appropriately.

This also adds a new phase to the integration test that validates the `1.x` release line of the `jsii` compiler can compile projects that depend on packages built by the current one, and which make use of TypeScript-3.9-unsupported features.

Closes aws/jsii#3501

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0