### PR TITLE
feat: prohibit use of separate write type on properties

### DIFF
--- a/src/jsii-diagnostic.ts
+++ b/src/jsii-diagnostic.ts
@@ -280,6 +280,12 @@ export class JsiiDiagnostic implements ts.Diagnostic {
     name: 'typescript-restrictions/duplicate-enum-value',
   });
 
+  public static readonly JSII_1005_SEPARATE_WRITE_TYPE = Code.error({
+    code: 1005,
+    formatter: () => 'Visible property signatures cannot use a separate write type. Use the same type as the getter.',
+    name: 'typescript-restrictions/separate-write-type',
+  });
+
   public static readonly JSII_1999_UNSUPPORTED = Code.error({
     code: 1999,
     formatter: ({ what, alternative }: { what: string; alternative?: string }) =>

--- a/test/__snapshots__/negatives.test.ts.snap
+++ b/test/__snapshots__/negatives.test.ts.snap
@@ -698,6 +698,19 @@ neg.reserved.emits-warning.ts:5:10 - warning JSII5018: "assert" is a reserved wo
 
 `;
 
+exports[`separate-write-type 1`] = `
+neg.separate-write-type.ts:8:26 - error JSII1005: Visible property signatures cannot use a separate write type. Use the same type as the getter.
+
+8   public set size(value: string | number | boolean) {
+                           ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  neg.separate-write-type.ts:4:22
+    4   public get size(): number {
+                           ~~~~~~
+    The getter signature is declared here
+
+`;
+
 exports[`static-const-name 1`] = `
 error JSII8003: Static constant names must use ALL_CAPS, PascalCase, or camelCase. Rename "MyClass.snake_case" to "SNAKE_CASE"
 

--- a/test/negatives/neg.separate-write-type.ts
+++ b/test/negatives/neg.separate-write-type.ts
@@ -1,0 +1,19 @@
+export class Thing {
+  private _size = 0;
+
+  public get size(): number {
+      return this._size;
+  }
+
+  public set size(value: string | number | boolean) {
+      let num = Number(value);
+
+      // Don't allow NaN and stuff.
+      if (!Number.isFinite(num)) {
+          this._size = 0;
+          return;
+      }
+
+      this._size = num;
+  }
+}

--- a/test/string-literal-types.test.ts
+++ b/test/string-literal-types.test.ts
@@ -40,7 +40,6 @@ test('test parsing string literal type with enum interpolation', () => {
 
 // ----------------------------------------------------------------------
 test('test parsing string literal type with number interpolation', () => {
-  debugger;
   const assembly = sourceToAssemblyHelper(`
     export interface UsesSTT {
       readonly foo: \`foo - \${number}\`


### PR DESCRIPTION
Separate write types are allowed on property setters since TypeScript 4.3, where a setter can accept more types than the getter's return type, granted the getter's return type is assignable to the setter's argument. This is however not a feature that can be modeled in the jsii type system, or that can be accurately represented in several target languages (e.g: C#).



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0