### PR TITLE
fix: correctly reject index signatures

### DIFF
--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -1656,9 +1656,11 @@ export class Assembler implements Emitter {
       | ts.InterfaceDeclaration
       | undefined;
 
-    for (const decl of (typeDecl?.members as readonly ts.Node[] | undefined)?.filter((mem) => ts.isIndexSignatureDeclaration(mem)) ?? []) {
-        // Index signatures (static or not) are not supported in the jsii type model.
-        this._diagnostics.push(JsiiDiagnostic.JSII_1999_UNSUPPORTED.create(decl, { what: 'Index signatures' }));
+    for (const decl of (typeDecl?.members as readonly ts.Node[] | undefined)?.filter((mem) =>
+      ts.isIndexSignatureDeclaration(mem),
+    ) ?? []) {
+      // Index signatures (static or not) are not supported in the jsii type model.
+      this._diagnostics.push(JsiiDiagnostic.JSII_1999_UNSUPPORTED.create(decl, { what: 'Index signatures' }));
     }
 
     for (const declaringType of [type, ...erasedBases]) {

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -1215,6 +1215,12 @@ export class Assembler implements Emitter {
           continue;
         }
 
+        if (ts.isIndexSignatureDeclaration(memberDecl)) {
+          // Index signatures (static or not) are not supported in the jsii type model.
+          this._diagnostics.push(JsiiDiagnostic.JSII_1999_UNSUPPORTED.create(memberDecl, { what: 'Index signatures' }));
+          continue;
+        }
+
         const member: ts.Symbol = ts.isConstructorDeclaration(memberDecl)
           ? (memberDecl as any).symbol
           : this._typeChecker.getSymbolAtLocation(ts.getNameOfDeclaration(memberDecl)!)!;
@@ -1649,6 +1655,11 @@ export class Assembler implements Emitter {
       | ts.ClassLikeDeclaration
       | ts.InterfaceDeclaration
       | undefined;
+
+    for (const decl of (typeDecl?.members as readonly ts.Node[] | undefined)?.filter((mem) => ts.isIndexSignatureDeclaration(mem)) ?? []) {
+        // Index signatures (static or not) are not supported in the jsii type model.
+        this._diagnostics.push(JsiiDiagnostic.JSII_1999_UNSUPPORTED.create(decl, { what: 'Index signatures' }));
+    }
 
     for (const declaringType of [type, ...erasedBases]) {
       for (const member of declaringType.getProperties()) {

--- a/test/__snapshots__/negatives.test.ts.snap
+++ b/test/__snapshots__/negatives.test.ts.snap
@@ -364,6 +364,20 @@ neg.implements-class.ts:1:1 - error JSII3005: Type "jsii.NotAnInterface" cannot 
 
 `;
 
+exports[`index-signatures 1`] = `
+neg.index-signatures.ts:4:3 - error JSII1999: Index signatures are not supported in jsii APIs.
+
+4   readonly [key: string]: number;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+neg.index-signatures.ts:9:3 - error JSII1999: Index signatures are not supported in jsii APIs.
+
+9   static readonly [key: string]: string;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+`;
+
 exports[`inheritance-changes-types.1 1`] = `
 error JSII5003: "jsii.SomethingSpecific#returnSomething" changes the return type to "jsii.Subclass" when overriding jsii.Something. Change it to "jsii.Superclass"
 

--- a/test/__snapshots__/negatives.test.ts.snap
+++ b/test/__snapshots__/negatives.test.ts.snap
@@ -367,12 +367,12 @@ neg.implements-class.ts:1:1 - error JSII3005: Type "jsii.NotAnInterface" cannot 
 exports[`index-signatures 1`] = `
 neg.index-signatures.ts:4:3 - error JSII1999: Index signatures are not supported in jsii APIs.
 
-4   readonly [key: string]: number;
+4   readonly [key: symbol]: number;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 neg.index-signatures.ts:9:3 - error JSII1999: Index signatures are not supported in jsii APIs.
 
-9   static readonly [key: string]: string;
+9   static readonly [key: symbol]: string;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 

--- a/test/negatives/neg.index-signatures.ts
+++ b/test/negatives/neg.index-signatures.ts
@@ -1,12 +1,12 @@
 export interface IWithIndex {
   readonly bamboodle: number;
   // This is not supported on the jsii type system!
-  readonly [key: string]: number;
+  readonly [key: symbol]: number;
 }
 
 export class WithStaticIndex {
   // This is not supported on the jsii type system!
-  static readonly [key: string]: string;
+  static readonly [key: symbol]: string;
 
   private constructor() { }
 }

--- a/test/negatives/neg.index-signatures.ts
+++ b/test/negatives/neg.index-signatures.ts
@@ -1,0 +1,12 @@
+export interface IWithIndex {
+  readonly bamboodle: number;
+  // This is not supported on the jsii type system!
+  readonly [key: string]: number;
+}
+
+export class WithStaticIndex {
+  // This is not supported on the jsii type system!
+  static readonly [key: string]: string;
+
+  private constructor() { }
+}


### PR DESCRIPTION
Index signatures cannot be represented in the jsii type model and should be rejected. TypeScript 4.3 also introduces support for static index signatures, which should be rejected, too.

Starting with TypeScript 4.4, Symbols can be used as keys on index signatures. Neither symbols nor index signatures are supported, but only the later should be reported (to avoid double-reporting issues).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0