### PR TITLE
feat: accept template string pattern in index signatures

### DIFF
--- a/test/string-literal-types.test.ts
+++ b/test/string-literal-types.test.ts
@@ -1,3 +1,4 @@
+import { CollectionKind, PrimitiveType, Type, TypeKind } from '@jsii/spec';
 import { sourceToAssemblyHelper } from '../lib';
 
 // ----------------------------------------------------------------------
@@ -17,7 +18,7 @@ test('test parsing string literal type with enum interpolation', () => {
     assembly: 'testpkg',
     datatype: true,
     fqn: 'testpkg.UsesSTT',
-    kind: 'interface',
+    kind: TypeKind.Interface,
     properties: [
       {
         abstract: true,
@@ -28,19 +29,18 @@ test('test parsing string literal type with enum interpolation', () => {
         },
         name: 'foo',
         type: {
-          primitive: 'string',
+          primitive: PrimitiveType.String,
         },
       },
     ],
     locationInModule: { filename: 'index.ts', line: 7 },
     name: 'UsesSTT',
     symbolId: 'index:UsesSTT',
-  });
+  } satisfies Type);
 });
 
 // ----------------------------------------------------------------------
 test('test parsing string literal type with number interpolation', () => {
-  debugger;
   const assembly = sourceToAssemblyHelper(`
     export interface UsesSTT {
       readonly foo: \`foo - \${number}\`
@@ -51,7 +51,7 @@ test('test parsing string literal type with number interpolation', () => {
     assembly: 'testpkg',
     datatype: true,
     fqn: 'testpkg.UsesSTT',
-    kind: 'interface',
+    kind: TypeKind.Interface,
     properties: [
       {
         abstract: true,
@@ -62,12 +62,50 @@ test('test parsing string literal type with number interpolation', () => {
         },
         name: 'foo',
         type: {
-          primitive: 'string',
+          primitive: PrimitiveType.String,
         },
       },
     ],
     locationInModule: { filename: 'index.ts', line: 2 },
     name: 'UsesSTT',
     symbolId: 'index:UsesSTT',
-  });
+  } satisfies Type);
+});
+
+// ----------------------------------------------------------------------
+test('test parsing string literal type in index signature', () => {
+  const assembly = sourceToAssemblyHelper(`
+    export interface UsesSTT {
+      readonly foo: { [key: \`foo - \${number}\`]: boolean };
+    }
+  `);
+
+  expect(assembly.types!['testpkg.UsesSTT']).toEqual({
+    assembly: 'testpkg',
+    datatype: true,
+    fqn: 'testpkg.UsesSTT',
+    kind: TypeKind.Interface,
+    properties: [
+      {
+        abstract: true,
+        immutable: true,
+        locationInModule: {
+          filename: 'index.ts',
+          line: 3,
+        },
+        name: 'foo',
+        type: {
+          collection: {
+            kind: CollectionKind.Map,
+            elementtype: {
+              primitive: PrimitiveType.Boolean,
+            },
+          },
+        },
+      },
+    ],
+    locationInModule: { filename: 'index.ts', line: 2 },
+    name: 'UsesSTT',
+    symbolId: 'index:UsesSTT',
+  } satisfies Type);
 });


### PR DESCRIPTION
Treat `{ [key: `template-${number}`]: T }` as equivalent to `{ [key: string]: T }` in the jsii type model, consistent with handling of `template-${number}` in other places.

Template string pattern index signatures was added in TypeScript 4.4.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0