### PR TITLE
chore: add test for auto-accessors

### DIFF
--- a/test/auto-accessors.test.ts
+++ b/test/auto-accessors.test.ts
@@ -1,0 +1,34 @@
+import { PrimitiveType, Type, TypeKind } from '@jsii/spec';
+import { sourceToAssemblyHelper } from '../lib';
+
+// ----------------------------------------------------------------------
+test('auto accessors', () => {
+  const assembly = sourceToAssemblyHelper(`
+    export class Automatic {
+      public accessor property: boolean = true;
+
+      private constructor(){}
+    }
+  `);
+
+  expect(assembly.types!['testpkg.Automatic']).toEqual({
+    assembly: 'testpkg',
+    fqn: 'testpkg.Automatic',
+    kind: TypeKind.Class,
+    properties: [
+      {
+        locationInModule: {
+          filename: 'index.ts',
+          line: 3,
+        },
+        name: 'property',
+        type: {
+          primitive: PrimitiveType.Boolean,
+        },
+      },
+    ],
+    locationInModule: { filename: 'index.ts', line: 2 },
+    name: 'Automatic',
+    symbolId: 'index:Automatic',
+  } satisfies Type);
+});


### PR DESCRIPTION
Auto accessor support was introduced in TypeScript 4.9 and allows introducing accessor-implemented properties (backed by an implicit `#private` property) using the `accessor` keyword. This is not compatible with the use of `readonly` (such properties are always read-write), and is useful to provide implementation of accessor-based abstract properties, or to override accessor-based parent members.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0