### PR TITLE
chore: Property Inference Tests

### DIFF
--- a/test/property-inference.test.ts
+++ b/test/property-inference.test.ts
@@ -1,0 +1,78 @@
+import { sourceToAssemblyHelper } from '../lib';
+
+// ----------------------------------------------------------------------
+test('Class properties are inferred from the constructor', () => {
+  const assembly = sourceToAssemblyHelper(`
+    export class Dog {
+        ageInDogYears;
+        breed;
+        constructor(years: number, breed: string) {
+            // because dogYears and regular years are different!
+            this.ageInDogYears = years * 7;
+            this.breed = breed;
+        }
+    }
+  `);
+
+  expect(assembly.types!['testpkg.Dog']).toEqual({
+    assembly: 'testpkg',
+    fqn: 'testpkg.Dog',
+    kind: 'class',
+    initializer: {
+      locationInModule: { filename: 'index.ts', line: 5 },
+      parameters: [
+        {
+          name: 'years',
+          type: {
+            primitive: 'number',
+          },
+        },
+        {
+          name: 'breed',
+          type: {
+            primitive: 'string',
+          },
+        },
+      ],
+    },
+    locationInModule: { filename: 'index.ts', line: 2 },
+    name: 'Dog',
+    properties: [
+      {
+        locationInModule: { filename: 'index.ts', line: 3 },
+        name: 'ageInDogYears',
+        type: {
+          primitive: 'number',
+        },
+      },
+      {
+        locationInModule: { filename: 'index.ts', line: 4 },
+        name: 'breed',
+        type: {
+          primitive: 'string',
+        },
+      },
+    ],
+    symbolId: 'index:Dog',
+  });
+});
+
+test('Class property can not be inferred if property is potentially undefinied', () => {
+  expect(() =>
+    sourceToAssemblyHelper(`
+      class Square {
+        sideLength;
+    
+        constructor(sideLength: number) {
+            if (Math.random()) {
+                this.sideLength = sideLength;
+            }
+        }
+    
+        get area() {
+            return this.sideLength ** 2;
+        }
+    }
+      `),
+  ).toThrow(/There were compiler errors/);
+});


### PR DESCRIPTION
Created tests to verify class property types can be inferred from their usage. Also tested to make sure that if the class property wasn't guaranteed to be defined, the compiler should output an error

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0