### PR TITLE
chore: awaited/promise type alias tests

### DIFF
--- a/test/type-alias.test.ts
+++ b/test/type-alias.test.ts
@@ -1,0 +1,81 @@
+import { sourceToAssemblyHelper } from '../lib';
+
+// ----------------------------------------------------------------------
+test('type aliases with awaited and promise types', () => {
+  const assembly = sourceToAssemblyHelper(`
+    type AwaitedPromiseString = Awaited<Promise<string>>;
+    type AwaitedPromisePromiseNumber = Awaited<Promise<Promise<number>>>;
+    type AwaitedBooleanOrPromiseNumber = Awaited<boolean | Promise<number>>;
+
+    export class AwaitedPromiseTypes {
+        bar: AwaitedPromiseString;
+        buzz: AwaitedPromisePromiseNumber;
+        bam: AwaitedBooleanOrPromiseNumber;
+        constructor(foo: AwaitedPromiseString, 
+                    fizz: AwaitedPromisePromiseNumber, 
+                    flam: AwaitedBooleanOrPromiseNumber) {
+            this.bar = foo;
+            this.buzz = fizz;
+            this.bam = flam;
+        }
+    }
+  `);
+  expect(assembly.types!['testpkg.AwaitedPromiseTypes']).toEqual({
+    assembly: 'testpkg',
+    fqn: 'testpkg.AwaitedPromiseTypes',
+    kind: 'class',
+    initializer: {
+        locationInModule: { filename: 'index.ts', line: 10 },
+        parameters: [
+            {
+                name: 'foo',
+                type: {
+                    "primitive": "string",
+                },
+            },
+            {
+                name: 'fizz',
+                type: {
+                    "primitive": "number",
+                },
+            },
+            {
+                name: 'flam',
+                type: {
+                    "union": {
+                        "types": [{"primitive": "number",}, {"primitive": "boolean",} ]
+                    }
+                },
+            },
+        ],
+    },
+    locationInModule: { filename: 'index.ts', line: 6 },
+    name: 'AwaitedPromiseTypes',
+    properties: [
+        {
+            locationInModule: { filename: 'index.ts', line: 9 },
+            name: 'bam',
+            type: {
+                "union": {
+                    "types": [{"primitive": "number",}, {"primitive": "boolean",} ]
+                }
+            },
+        },
+        {
+            locationInModule: { filename: 'index.ts', line: 7 },
+            name: 'bar',
+            type: {
+                "primitive": "string",
+            },
+        },
+        {
+            locationInModule: { filename: 'index.ts', line: 8 },
+            name: 'buzz',
+            type: {
+                "primitive": "number",
+            },
+        },
+    ],
+    symbolId: 'index:AwaitedPromiseTypes',
+    });
+});


### PR DESCRIPTION
as per https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html. There were improvements to type aliasing to allow for a new utility type `Awaited`. Wrote a new test to verify these improvements


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0