### PR TITLE
fix: do not pass semver objects to downlevel-dts

### DIFF
--- a/src/ambient/downlevel-dts.ts
+++ b/src/ambient/downlevel-dts.ts
@@ -1,7 +1,5 @@
 /** Hand-written declaration for the downlevel-dts module */
 declare module 'downlevel-dts' {
-  import { SemVer } from 'semver';
-
   /**
    * Rewrite .d.ts files created by any version of TypeScript so that they work
    * with TypeScript 3.4 or later. It does this by converting code with new
@@ -10,6 +8,12 @@ declare module 'downlevel-dts' {
    * @param src           the directory containing the original .d.ts files
    * @param target        the directory in which to place re-written files
    * @param targetVersion the target TypeScript version compatibility
+   *
+   * @note The "real" signature would allow semver.SemVer instances to be
+   *       provided as `targetVersion`, but some code-path involves an
+   *       `instanceof` test which will fail if somehow `downlevel-dts` is
+   *       provided with its own install of the `semver` dependency, which we
+   *       cannot control, so we disallow using `semver.SemVer` instances here.
    */
-  export function main(src: string, target: string, targetVersion: string | SemVer): void;
+  export function main(src: string, target: string, targetVersion: string): void;
 }

--- a/src/downlevel-dts.ts
+++ b/src/downlevel-dts.ts
@@ -58,7 +58,7 @@ export function emitDownleveledDeclarations({ packageJson, projectRoot, tsc }: P
     // We'll emit down-leveled declarations in a temporary directory...
     const workdir = mkdtempSync(join(tmpdir(), `downlevel-dts-${breakpoint}-${basename(projectRoot)}-`));
     try {
-      downlevel(projectRoot, workdir, breakpoint);
+      downlevel(projectRoot, workdir, breakpoint.version);
       for (const dts of walkDirectory(workdir)) {
         const original = readFileSync(join(projectRoot, dts), 'utf-8');
         const downleveled = readFileSync(join(workdir, dts), 'utf-8');


### PR DESCRIPTION
If `downlevel-dts` has a different `semver` dependency instance than the jsii compiler, an `instanceof` check internal to `semver` fails and produces a `TypeError` exception. We can easily avoid this by always providing the target version as a `string`, which leads to `downlevel-dts` ultimately using its own `semver` instance to turn it into the `semver.SemVer` object it needs.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0