### PR TITLE
feat: allow marking indexers @internal

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -6,7 +6,7 @@ import * as ts from 'typescript';
 
 import { Assembler } from './assembler';
 import * as Case from './case';
-import { emitDownleveledDeclarations } from './downlevel-dts';
+import { emitDownleveledDeclarations, TYPES_COMPAT } from './downlevel-dts';
 import { Emitter } from './emitter';
 import { JsiiDiagnostic } from './jsii-diagnostic';
 import { ProjectInfo } from './project-info';
@@ -323,6 +323,7 @@ export class Compiler implements Emitter {
       include: [pi.tsc?.rootDir != null ? path.join(pi.tsc.rootDir, '**', '*.ts') : path.join('**', '*.ts')],
       exclude: [
         'node_modules',
+        pi.tsc?.outDir != null ? path.resolve(pi.tsc.outDir, TYPES_COMPAT) : TYPES_COMPAT,
         ...(pi.excludeTypescript ?? []),
         ...(pi.tsc?.outDir != null &&
         (pi.tsc?.rootDir == null || path.resolve(pi.tsc.outDir).startsWith(path.resolve(pi.tsc.rootDir) + path.sep))

--- a/src/jsii-diagnostic.ts
+++ b/src/jsii-diagnostic.ts
@@ -288,8 +288,18 @@ export class JsiiDiagnostic implements ts.Diagnostic {
 
   public static readonly JSII_1999_UNSUPPORTED = Code.error({
     code: 1999,
-    formatter: ({ what, alternative }: { what: string; alternative?: string }) =>
-      `${what} are not supported in jsii APIs.${alternative ? ` Consider using ${alternative} instead.` : ''}`,
+    formatter: ({
+      what,
+      alternative,
+      suggestInternal,
+    }: {
+      what: string;
+      alternative?: string;
+      suggestInternal?: boolean;
+    }) =>
+      `${what} are not supported in jsii APIs.${alternative ? ` Consider using ${alternative} instead.` : ''}${
+        suggestInternal ? ` This declaration must${alternative ? ' otherwise' : ''} be marked @internal.` : ''
+      }`,
     name: 'typescript-restrictions/unsupported',
   });
 
@@ -775,7 +785,10 @@ export class JsiiDiagnostic implements ts.Diagnostic {
   }
 
   public addRelatedInformation(node: ts.Node, message: JsiiDiagnostic['messageText']): this {
-    this.relatedInformation.push(JsiiDiagnostic.JSII_9999_RELATED_INFO.create(node, message));
+    // Don't relate info into the TypeScript standard library
+    if (!/[\\/]typescript[\\/]lib[\\/]lib\..+\.d\.ts$/.test(node.getSourceFile().fileName)) {
+      this.relatedInformation.push(JsiiDiagnostic.JSII_9999_RELATED_INFO.create(node, message));
+    }
     // Clearing out #formatted, as this would no longer be the correct string.
     this.#formatted = undefined;
     return this;

--- a/test/__snapshots__/negatives.test.ts.snap
+++ b/test/__snapshots__/negatives.test.ts.snap
@@ -365,12 +365,12 @@ neg.implements-class.ts:1:1 - error JSII3005: Type "jsii.NotAnInterface" cannot 
 `;
 
 exports[`index-signatures 1`] = `
-neg.index-signatures.ts:4:3 - error JSII1999: Index signatures are not supported in jsii APIs.
+neg.index-signatures.ts:4:3 - error JSII1999: Index signatures are not supported in jsii APIs. This declaration must be marked @internal.
 
 4   readonly [key: symbol]: number;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-neg.index-signatures.ts:9:3 - error JSII1999: Index signatures are not supported in jsii APIs.
+neg.index-signatures.ts:9:3 - error JSII1999: Index signatures are not supported in jsii APIs. This declaration must be marked @internal.
 
 9   static readonly [key: symbol]: string;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -609,14 +609,6 @@ neg.omit.1.ts:7:33 - error JSII3004: Illegal extends clause for an exported API:
 7 export interface BarBaz extends Omit<FooBar, 'foo'> {
                                   ~~~~~~~~~~~~~~~~~~~
 
-  ../../node_modules/typescript/lib/lib.es5.d.ts:1583:35
-    1583 type Pick<T, K extends keyof T> = {
-                                           ~
-    1584     [P in K]: T[P];
-         ~~~~~~~~~~~~~~~~~~~
-    1585 };
-         ~
-    The invalid super type is declared here.
 
 `;
 
@@ -626,14 +618,6 @@ neg.omit.2.ts:7:32 - error JSII3004: Illegal implements clause for an exported A
 7 export class BarBaz implements Omit<FooBar, 'foo'> {
                                  ~~~~~~~~~~~~~~~~~~~
 
-  ../../node_modules/typescript/lib/lib.es5.d.ts:1583:35
-    1583 type Pick<T, K extends keyof T> = {
-                                           ~
-    1584     [P in K]: T[P];
-         ~~~~~~~~~~~~~~~~~~~
-    1585 };
-         ~
-    The invalid super type is declared here.
 
 `;
 

--- a/test/compiler.test.ts
+++ b/test/compiler.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { loadAssemblyFromPath, SPEC_FILE_NAME, SPEC_FILE_NAME_COMPRESSED } from '@jsii/spec';
 
 import { Compiler } from '../src/compiler';
+import { TYPES_COMPAT } from '../src/downlevel-dts';
 import { ProjectInfo } from '../src/project-info';
 
 describe(Compiler, () => {
@@ -265,7 +266,7 @@ function expectedTypeScriptConfig() {
       target: 'ES2020',
       tsBuildInfoFile: 'tsconfig.tsbuildinfo',
     },
-    exclude: ['node_modules'],
+    exclude: ['node_modules', TYPES_COMPAT],
     include: [join('**', '*.ts')],
   };
 }

--- a/test/negatives/neg.index-signatures.ts
+++ b/test/negatives/neg.index-signatures.ts
@@ -10,3 +10,31 @@ export class WithStaticIndex {
 
   private constructor() { }
 }
+
+export interface InternalIsIgnoredOnInterface {
+  readonly hello: number;
+
+  /**
+   * There should NOT be an error marker on this index signature, as it's marked
+   * internal.
+   *
+   *  @internal
+   */
+  readonly [key: string]: number;
+}
+
+export class InternalIsIgnoredOnClass {
+  readonly hello: number;
+
+  /**
+   * There should NOT be an error marker on this index signature, as it's marked
+   * internal.
+   *
+   *  @internal
+   */
+  readonly [key: string]: number;
+
+  private constructor() {
+    this.hello = 1337;
+  }
+}


### PR DESCRIPTION
There may be internal use-cases for declaring indexer properties, and those can be erased using the `@internal` JSDoc tag. This allows using such declarations while explicitly hiding them from the library's API.

Additionally improved error messaging to remove related information when it points to types in the TypeScript standard library, as those are often fairly complex and their declaration is not expected to be shown to users.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0