### PR TITLE
feat: add "@jsii ignore" directive

### DIFF
--- a/src/directives.ts
+++ b/src/directives.ts
@@ -1,0 +1,102 @@
+import * as ts from 'typescript';
+import { JsiiDiagnostic } from './jsii-diagnostic';
+
+/**
+ * TSDoc-style directives that can be attached to a symbol.
+ */
+export class Directives {
+  /**
+   * Obtains the `Directives` for a given TypeScript AST node.
+   *
+   * @param node         the node for which directives are requested.
+   * @param onDiagnostic a callback invoked whenever a diagnostic message is
+   *                     emitted when parsing directives.
+   */
+  public static of(node: ts.Node, onDiagnostic: (diag: JsiiDiagnostic) => void): Directives {
+    const found = Directives.#CACHE.get(node);
+    if (found != null) {
+      return found;
+    }
+
+    const directives = new Directives(node, onDiagnostic);
+    Directives.#CACHE.set(node, directives);
+    return directives;
+  }
+
+  static readonly #CACHE = new WeakMap<ts.Node, Directives>();
+
+  /** Whether the node has the `@internal` JSDoc tag. */
+  public readonly tsInternal?: ts.JSDocTag;
+  /** Whether the node has the `@jsii ignore` directive set. */
+  public readonly ignore?: ts.JSDocComment | ts.JSDocTag;
+  /** Whether the node has the `@jsii struct` directive set. */
+  public readonly struct?: ts.JSDocComment | ts.JSDocTag;
+
+  private constructor(node: ts.Node, onDiagnostic: (diag: JsiiDiagnostic) => void) {
+    for (const tag of ts.getJSDocTags(node)) {
+      switch (tag.tagName.text) {
+        case 'internal':
+          this.tsInternal ??= tag;
+          break;
+        case 'jsii':
+          const comments = getComments(tag);
+          if (comments.length === 0) {
+            onDiagnostic(JsiiDiagnostic.JSII_2000_MISSING_DIRECTIVE_ARGUMENT.create(tag));
+            continue;
+          }
+          for (const { text, jsdocNode } of comments) {
+            switch (text) {
+              case 'ignore':
+                this.ignore ??= jsdocNode;
+                break;
+              default:
+                onDiagnostic(JsiiDiagnostic.JSII_2999_UNKNOWN_DIRECTIVE.create(jsdocNode, text));
+                break;
+            }
+          }
+          break;
+        default: // Ignore
+      }
+    }
+  }
+}
+
+function getComments(tag: ts.JSDocTag): Comment[] {
+  if (tag.comment == null) {
+    return [];
+  }
+
+  if (typeof tag.comment === 'string') {
+    const text = tag.comment.trim();
+    return text
+      ? text.split(/[\n,]/).flatMap((line) => {
+          line = line.trim();
+          return line ? [{ text: line, jsdocNode: tag }] : [];
+        })
+      : [];
+  }
+
+  // Possible per the type signature in the compiler, however not sure in which conditions.
+  return tag.comment.flatMap((jsdocNode): Comment[] => {
+    let text: string;
+    switch (jsdocNode.kind) {
+      case ts.SyntaxKind.JSDocText:
+        text = jsdocNode.text;
+        break;
+      case ts.SyntaxKind.JSDocLink:
+      case ts.SyntaxKind.JSDocLinkCode:
+      case ts.SyntaxKind.JSDocLinkPlain:
+        text = jsdocNode.name
+          ? `${jsdocNode.name.getText(jsdocNode.name.getSourceFile())}: ${jsdocNode.text}`
+          : jsdocNode.text;
+        break;
+    }
+    text = text.trim();
+    return text ? [{ text, jsdocNode }] : [];
+  });
+}
+
+interface Comment {
+  readonly text: string;
+  readonly jsdocNode: ts.JSDocComment | ts.JSDocTag;
+}

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -50,6 +50,9 @@ enum DocTag {
   EXAMPLE = 'example',
   STABILITY = 'stability',
   STRUCT = 'struct',
+
+  // Not forwarded, this is compiler-internal.
+  JSII = 'jsii',
 }
 
 const RECOGNIZED_TAGS: ReadonlySet<String> = new Set(Object.values(DocTag));
@@ -89,7 +92,8 @@ function parseDocParts(comments: string | undefined, tags: ts.JSDocTagInfo[]): D
   const tagNames = new Map<string, string | undefined>();
   for (const tag of tags) {
     // 'param' gets parsed as a tag and as a comment for a method
-    if (tag.name !== DocTag.PARAM) {
+    // 'jsii' is internal-only and shouldn't surface in the API doc
+    if (tag.name !== DocTag.PARAM && tag.name !== DocTag.JSII) {
       tagNames.set(tag.name, tag.text && ts.displayPartsToString(tag.text));
     }
   }

--- a/src/jsii-diagnostic.ts
+++ b/src/jsii-diagnostic.ts
@@ -298,13 +298,36 @@ export class JsiiDiagnostic implements ts.Diagnostic {
       suggestInternal?: boolean;
     }) =>
       `${what} are not supported in jsii APIs.${alternative ? ` Consider using ${alternative} instead.` : ''}${
-        suggestInternal ? ` This declaration must${alternative ? ' otherwise' : ''} be marked @internal.` : ''
+        suggestInternal
+          ? ` This declaration must${alternative ? ' otherwise' : ''} be marked "@internal" or "@jsii ignore".`
+          : ''
       }`,
     name: 'typescript-restrictions/unsupported',
   });
 
   //////////////////////////////////////////////////////////////////////////////
-  // 2000 => 2999 -- RESERVED
+  // 2000 => 2999 -- INCORRECT USE OF THE @jsii DIRECTIVE
+  public static readonly JSII_2000_MISSING_DIRECTIVE_ARGUMENT = Code.warning({
+    code: 2000,
+    formatter: () =>
+      'Missing argument to @jsii directive. Refer to the jsii compiler documentation for more information.',
+    name: 'jsii-directive/missing-argument',
+  });
+
+  public static readonly JSII_2100_STRUCT_ON_NON_INTERFACE = Code.warning({
+    code: 2100,
+    formatter: () => 'The "@jsii struct" directive is only applicable to interface declarations.',
+    name: 'jsii-directive/struct-on-non-interface',
+  });
+
+  public static readonly JSII_2999_UNKNOWN_DIRECTIVE = Code.warning({
+    code: 2999,
+    formatter: (text: string) =>
+      `Unknown @jsii directive: ${JSON.stringify(
+        text,
+      )}. Refer to the jsii compiler documentation for more information.`,
+    name: 'jsii-directive/unknown',
+  });
 
   //////////////////////////////////////////////////////////////////////////////
   // 3000 => 3999 -- TYPE MODEL COHERENCE

--- a/test/__snapshots__/negatives.test.ts.snap
+++ b/test/__snapshots__/negatives.test.ts.snap
@@ -365,12 +365,12 @@ neg.implements-class.ts:1:1 - error JSII3005: Type "jsii.NotAnInterface" cannot 
 `;
 
 exports[`index-signatures 1`] = `
-neg.index-signatures.ts:4:3 - error JSII1999: Index signatures are not supported in jsii APIs. This declaration must be marked @internal.
+neg.index-signatures.ts:4:3 - error JSII1999: Index signatures are not supported in jsii APIs. This declaration must be marked "@internal" or "@jsii ignore".
 
 4   readonly [key: symbol]: number;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-neg.index-signatures.ts:9:3 - error JSII1999: Index signatures are not supported in jsii APIs. This declaration must be marked @internal.
+neg.index-signatures.ts:9:3 - error JSII1999: Index signatures are not supported in jsii APIs. This declaration must be marked "@internal" or "@jsii ignore".
 
 9   static readonly [key: symbol]: string;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/test/directives.test.ts
+++ b/test/directives.test.ts
@@ -1,0 +1,266 @@
+import * as ts from 'typescript';
+import { JsiiDiagnostic } from '../src';
+import { Directives } from '../src/directives';
+import { formatDiagnostic, stripAnsi } from '../src/utils';
+
+test('non-directive tags', () => {
+  // Given
+  const sourceFile = ts.createSourceFile(
+    'test.ts',
+    `export class Internal { /** @param param some parameter */ public constructor(public readonly param: unknown) {} }`,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const classDecl = sourceFile.statements[0] as ts.ClassDeclaration;
+  const ctorDecl = classDecl.members[0];
+
+  // When
+  const directives = Directives.of(ctorDecl, unexpectedDiagnostic);
+
+  // Then
+  expect(directives.tsInternal).toBeFalsy();
+  expect(directives.ignore).toBeFalsy();
+});
+
+describe('@internal', () => {
+  test('set on declaration', () => {
+    // Given
+    const sourceFile = ts.createSourceFile(
+      'test.ts',
+      `/** @internal */ export class Internal { public constructor() {} }`,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+    const classDecl = sourceFile.statements[0];
+
+    // When
+    const directives = Directives.of(classDecl, unexpectedDiagnostic);
+
+    // Then
+    expect(directives.tsInternal).toBeTruthy();
+    expect(directives.ignore).toBeFalsy();
+  });
+
+  test('set on parent declaration', () => {
+    // Given
+    const sourceFile = ts.createSourceFile(
+      'test.ts',
+      `/** @internal */ export class Internal { public constructor() {} }`,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+    const classDecl = sourceFile.statements[0] as ts.ClassDeclaration;
+    const ctorDecl = classDecl.members[0];
+
+    // When
+    const directives = Directives.of(ctorDecl, unexpectedDiagnostic);
+
+    // Then
+    expect(directives.tsInternal).toBeFalsy();
+    expect(directives.ignore).toBeFalsy();
+  });
+});
+
+describe('@jsii', () => {
+  test('without content', () => {
+    // Given
+    const sourceFile = ts.createSourceFile(
+      'test.ts',
+      `/** @jsii */ export class Internal { public constructor() {} }`,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+    const classDecl = sourceFile.statements[0];
+    let hadDiagnostic = false;
+    const onDiagnostic = (diag: JsiiDiagnostic) => {
+      expect(hadDiagnostic).toBeFalsy();
+      const formatted = formatDiagnostic(diag, __dirname);
+      expect(stripAnsi(formatted)).toMatchInlineSnapshot(`
+        "test.ts:1:5 - warning JSII2000: Missing argument to @jsii directive. Refer to the jsii compiler documentation for more information.
+
+        1 /** @jsii */ export class Internal { public constructor() {} }
+              ~~~~~~
+
+        "
+      `);
+      hadDiagnostic = true;
+    };
+
+    // When
+    const directives = Directives.of(classDecl, onDiagnostic);
+
+    // Then
+    expect(hadDiagnostic).toBeTruthy();
+    expect(directives.tsInternal).toBeFalsy();
+    expect(directives.ignore).toBeFalsy();
+  });
+
+  test('with unknown directive', () => {
+    // Given
+    const sourceFile = ts.createSourceFile(
+      'test.ts',
+      `/** @jsii absolutely-not-a-directive */ export class Internal { public constructor() {} }`,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+    const classDecl = sourceFile.statements[0];
+    let hadDiagnostic = false;
+    const onDiagnostic = (diag: JsiiDiagnostic) => {
+      expect(hadDiagnostic).toBeFalsy();
+      const formatted = formatDiagnostic(diag, __dirname);
+      expect(stripAnsi(formatted)).toMatchInlineSnapshot(`
+        "test.ts:1:5 - warning JSII2999: Unknown @jsii directive: "absolutely-not-a-directive". Refer to the jsii compiler documentation for more information.
+
+        1 /** @jsii absolutely-not-a-directive */ export class Internal { public constructor() {} }
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+        "
+      `);
+      hadDiagnostic = true;
+    };
+
+    // When
+    const directives = Directives.of(classDecl, onDiagnostic);
+
+    // Then
+    expect(hadDiagnostic).toBeTruthy();
+    expect(directives.tsInternal).toBeFalsy();
+    expect(directives.ignore).toBeFalsy();
+  });
+
+  test('one known, one unknown directive', () => {
+    // Given
+    const sourceFile = ts.createSourceFile(
+      'test.ts',
+      `/**
+       * @jsii absolutely-not-a-directive
+       * @jsii ignore
+       */
+      export class Ignored { public constructor() {} }`,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+    const classDecl = sourceFile.statements[0];
+    let hadDiagnostic = false;
+    const onDiagnostic = (diag: JsiiDiagnostic) => {
+      expect(hadDiagnostic).toBeFalsy();
+      const formatted = formatDiagnostic(diag, __dirname);
+      expect(stripAnsi(formatted)).toMatchInlineSnapshot(`
+        "test.ts:2:10 - warning JSII2999: Unknown @jsii directive: "absolutely-not-a-directive". Refer to the jsii compiler documentation for more information.
+
+        2        * @jsii absolutely-not-a-directive
+                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        3        * @jsii ignore
+          ~~~~~~~~~
+
+        "
+      `);
+      hadDiagnostic = true;
+    };
+
+    // When
+    const directives = Directives.of(classDecl, onDiagnostic);
+
+    // Then
+    expect(hadDiagnostic).toBeTruthy();
+    expect(directives.tsInternal).toBeFalsy();
+    expect(directives.ignore).toBeTruthy();
+  });
+
+  test('one known, one unknown directive in multi-line style', () => {
+    // Given
+    const sourceFile = ts.createSourceFile(
+      'test.ts',
+      `/**
+       * @jsii absolutely-not-a-directive
+       *       ignore
+       */
+      export class Ignored { public constructor() {} }`,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+    const classDecl = sourceFile.statements[0];
+    let hadDiagnostic = false;
+    const onDiagnostic = (diag: JsiiDiagnostic) => {
+      expect(hadDiagnostic).toBeFalsy();
+      const formatted = formatDiagnostic(diag, __dirname);
+      expect(stripAnsi(formatted)).toMatchInlineSnapshot(`
+        "test.ts:2:10 - warning JSII2999: Unknown @jsii directive: "absolutely-not-a-directive". Refer to the jsii compiler documentation for more information.
+
+        2        * @jsii absolutely-not-a-directive
+                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        3        *       ignore
+          ~~~~~~~~~~~~~~~~~~~~~
+        4        */
+          ~~~~~~~
+
+        "
+      `);
+      hadDiagnostic = true;
+    };
+
+    // When
+    const directives = Directives.of(classDecl, onDiagnostic);
+
+    // Then
+    expect(hadDiagnostic).toBeTruthy();
+    expect(directives.tsInternal).toBeFalsy();
+    expect(directives.ignore).toBeTruthy();
+  });
+
+  test('ignore declaration', () => {
+    // Given
+    const sourceFile = ts.createSourceFile(
+      'test.ts',
+      `/** @jsii ignore */ export class Ignored { public constructor() {} }`,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+    const classDecl = sourceFile.statements[0];
+
+    // When
+    const directives = Directives.of(classDecl, unexpectedDiagnostic);
+
+    // Then
+    expect(directives.tsInternal).toBeFalsy();
+    expect(directives.ignore).toBeTruthy();
+  });
+
+  test('ignore declaration on index signature', () => {
+    // Given
+    const sourceFile = ts.createSourceFile(
+      'test.ts',
+      `export class Ignored {
+        public constructor() {}
+        /** @jsii ignore */
+        [key: string]: unknown;
+      }`,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+    const classDecl = sourceFile.statements[0] as ts.ClassDeclaration;
+    const indexSignature = classDecl.members[1];
+
+    // When
+    const directives = Directives.of(indexSignature, unexpectedDiagnostic);
+
+    // Then
+    expect(directives.tsInternal).toBeFalsy();
+    expect(directives.ignore).toBeTruthy();
+  });
+});
+
+function unexpectedDiagnostic(diag: JsiiDiagnostic) {
+  const formatted = formatDiagnostic(diag, __dirname);
+  // Always causes an assertion error
+  expect(stripAnsi(formatted)).toBeUndefined();
+}

--- a/test/negatives/neg.index-signatures.ts
+++ b/test/negatives/neg.index-signatures.ts
@@ -16,9 +16,9 @@ export interface InternalIsIgnoredOnInterface {
 
   /**
    * There should NOT be an error marker on this index signature, as it's marked
-   * internal.
+   * jsii-ignore.
    *
-   *  @internal
+   * @jsii ignore
    */
   readonly [key: string]: number;
 }
@@ -28,9 +28,9 @@ export class InternalIsIgnoredOnClass {
 
   /**
    * There should NOT be an error marker on this index signature, as it's marked
-   * internal.
+   * jsii-ignore.
    *
-   *  @internal
+   *  @jsii ignore
    */
   readonly [key: string]: number;
 


### PR DESCRIPTION
Users can annotate declarations with `@jsii ignore` to explicitly opt them out of cross-language support. This still allows the declaration to be visible to Javascript & TypeScript consumers of the library, but it is not included in the jsii assembly, and is hence not available for use in other languages.

Example usage:
```ts
export interface StructWithExtraProperties {
  readonly propertyA: string;
  readonly propertyB: number;

  /**
   * The index signature is not supported by jsii across languages. This
   * allows it to be used in TypeScript and Javascript, but the library
   * author should have an alternate (perhaps less convenient or less
   * TypeScript-idiomatic) way to achieve the same intent for other
   * languages.
   *
   * @jsii ignore
   */
  readonly [key: string]: string | number;
}
```

This is semantically similar to `@internal` except it does not hide the declaration from Javascript consumers.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0