### PR TITLE
chore: write .npmignore in .types-compat folder

### DIFF
--- a/src/downlevel-dts.ts
+++ b/src/downlevel-dts.ts
@@ -94,6 +94,8 @@ export function emitDownleveledDeclarations({ packageJson, projectRoot, tsc }: P
     if (!existsSync(compatDir)) {
       mkdirSync(compatDir, { recursive: true });
       try {
+        // Write an empty .npmignore file so that npm pack doesn't use the .gitignore file...
+        writeFileSync(join(compatRoot, '.npmignore'), '\n', 'utf-8');
         // Make sure all of this is gitignored, out of courtesy...
         writeFileSync(join(compatRoot, '.gitignore'), '*\n', 'utf-8');
       } catch {


### PR DESCRIPTION
Failure to do so results in npm@>=6 using the `.gitignore` file instead, and hence causing all down-leveled declarations to be lost in the ether.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0