### PR TITLE
feat: actually prohibit use of generic types

### DIFF
--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -1056,6 +1056,11 @@ export class Assembler implements Emitter {
       );
     }
 
+    const classDeclaration = type.symbol.valueDeclaration as ts.ClassDeclaration;
+    for (const typeParam of classDeclaration.typeParameters ?? []) {
+      this._diagnostics.push(JsiiDiagnostic.JSII_1006_GENERIC_TYPE.create(typeParam));
+    }
+
     const jsiiType: spec.ClassType = bindings.setClassRelatedNode(
       {
         assembly: this.projectInfo.name,
@@ -1065,7 +1070,7 @@ export class Assembler implements Emitter {
         namespace: ctx.namespace.length > 0 ? ctx.namespace.join('.') : undefined,
         docs: this._visitDocumentation(type.symbol, ctx).docs,
       },
-      type.symbol.valueDeclaration as ts.ClassDeclaration,
+      classDeclaration,
     );
 
     if (_isAbstract(type.symbol, jsiiType)) {
@@ -1674,6 +1679,10 @@ export class Assembler implements Emitter {
       | ts.ClassLikeDeclaration
       | ts.InterfaceDeclaration
       | undefined;
+
+    for (const typeParam of typeDecl?.typeParameters ?? []) {
+      this._diagnostics.push(JsiiDiagnostic.JSII_1006_GENERIC_TYPE.create(typeParam));
+    }
 
     for (const decl of (typeDecl?.members as ReadonlyArray<ts.ClassElement | ts.TypeElement> | undefined)?.filter(
       (mem) => ts.isIndexSignatureDeclaration(mem),

--- a/src/jsii-diagnostic.ts
+++ b/src/jsii-diagnostic.ts
@@ -286,6 +286,12 @@ export class JsiiDiagnostic implements ts.Diagnostic {
     name: 'typescript-restrictions/separate-write-type',
   });
 
+  public static readonly JSII_1006_GENERIC_TYPE = Code.error({
+    code: 1006,
+    formatter: () => 'Generic types are not supported because semantics are not uniform in target languages.',
+    name: 'typescript-restriction/generic-type',
+  });
+
   public static readonly JSII_1999_UNSUPPORTED = Code.error({
     code: 1999,
     formatter: ({

--- a/test/__snapshots__/negatives.test.ts.snap
+++ b/test/__snapshots__/negatives.test.ts.snap
@@ -237,6 +237,25 @@ neg.extend-struct.ts:6:1 - error JSII3007: Attempt to extend or implement struct
 
 `;
 
+exports[`generics 1`] = `
+neg.generics.ts:1:27 - error JSII1006: Generic types are not supported because semantics are not uniform in target languages.
+
+1 export class GenericClass<T extends object> {
+                            ~~~~~~~~~~~~~~~~
+
+neg.generics.ts:13:35 - error JSII1006: Generic types are not supported because semantics are not uniform in target languages.
+
+13 export interface IGenericBehavior<T extends object | string> {
+                                     ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+neg.generics.ts:9:32 - error JSII1006: Generic types are not supported because semantics are not uniform in target languages.
+
+9 export interface GenericStruct<T> {
+                                 ~
+
+
+`;
+
 exports[`implement-struct 1`] = `
 neg.implement-struct.ts:6:1 - error JSII3007: Attempt to extend or implement struct "jsii.Struct" from "jsii.Illegal"
 

--- a/test/negatives/neg.generics.ts
+++ b/test/negatives/neg.generics.ts
@@ -1,0 +1,15 @@
+export class GenericClass<T extends object> {
+  private constructor() { }
+
+  public retrieveGeneric(): T {
+    return {} as any;
+  }
+}
+
+export interface GenericStruct<T> {
+  readonly generic: T;
+}
+
+export interface IGenericBehavior<T extends object | string> {
+  genericMethod(param: T): void;
+}


### PR DESCRIPTION
The documentation says you can't use them, but the compiler never actually checked, and it silently ignored them (possibly reducing the type references to the "apparent type").


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0