### PR TITLE
fix: unable to import packages that declare `ts.outDir` for ts <= 3.9

### DIFF
--- a/src/downlevel-dts.ts
+++ b/src/downlevel-dts.ts
@@ -113,7 +113,7 @@ export function emitDownleveledDeclarations({ packageJson, projectRoot, tsc }: P
 
     // Register the type redirect in the typesVersions configuration
     typesVersions ??= {};
-    const from = [...(tsc?.outDir != null ? [tsc?.outDir] : []), '*'].join('/');
+    const from = '*';
     const to = [...(tsc?.outDir != null ? [tsc?.outDir] : []), TYPES_COMPAT, versionSuffix, '*'].join('/');
     // We put 2 candidate redirects (first match wins), so that it works for nested imports, too (see: https://github.com/microsoft/TypeScript/issues/43133)
     typesVersions[`<=${version}`] = { [from]: [to, `${to}/index.d.ts`] };


### PR DESCRIPTION
This was surfaced in [build failures](https://github.com/cdk8s-team/cdk8s-projen-common/actions/runs/4649361042/jobs/8227646520?pr=312) that bump the projen version, which was built with the latest `jsii-compiler` version:

```console
Error: src/components/backport/backport.ts:1:43 - error TS2307: Cannot find module 'projen' or its corresponding type declarations.

1 import { Component, JsonFile, Task } from 'projen';
                                            ~~~~~~~~
```

Basically the `lib/*` is preventing any imports to happen. I don't see a reason not to use `*` always, but this is the first i'm seeing this code so I might be missing something. 

### TODO

- [ ] Add a test that configures a package with `ts.outDir = lib` like most of our projen projects do

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0