### PR TITLE
feat: allow specifying a deprecation message regardless of stability

### DIFF
--- a/src/project-info.ts
+++ b/src/project-info.ts
@@ -466,7 +466,7 @@ function _validateStability(stability: string | undefined, deprecated: string | 
   if (!stability && deprecated) {
     stability = spec.Stability.Deprecated;
   } else if (deprecated && stability !== spec.Stability.Deprecated) {
-    throw new Error(
+    console.warn(
       `Package is deprecated (${deprecated}), but it's stability is ${stability} and not ${spec.Stability.Deprecated}`,
     );
   }


### PR DESCRIPTION
Previously, `jsii` required the package's stability to be `deprecated` if there cas a `deprecated` message configured. This is however problematic when a `stable` package reaches End-of-Support and the maintainer wants to signal this in npmjs.com.

Instead of failing, only log a warning to possibly raise awareness on an unintended configuration.

Foward-ports: aws/jsii#4145



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0