### PR TITLE
chore: update minNodeVersion to 16

### DIFF
--- a/.github/workflows/auto-tag-dev-v5.0.yml
+++ b/.github/workflows/auto-tag-dev-v5.0.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           cache: yarn
-          node-version: 14.18.0
+          node-version: 16.14.0
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build
@@ -48,7 +48,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           cache: yarn
-          node-version: 14.18.0
+          node-version: 16.14.0
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Set git identity

--- a/.github/workflows/auto-tag-dev.yml
+++ b/.github/workflows/auto-tag-dev.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           cache: yarn
-          node-version: 14.18.0
+          node-version: 16.14.0
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build
@@ -48,7 +48,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           cache: yarn
-          node-version: 14.18.0
+          node-version: 16.14.0
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Set git identity

--- a/.github/workflows/auto-tag-releases-v5.0.yml
+++ b/.github/workflows/auto-tag-releases-v5.0.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           cache: yarn
-          node-version: 14.18.0
+          node-version: 16.14.0
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build
@@ -48,7 +48,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           cache: yarn
-          node-version: 14.18.0
+          node-version: 16.14.0
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Set git identity

--- a/.github/workflows/auto-tag-releases.yml
+++ b/.github/workflows/auto-tag-releases.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           cache: yarn
-          node-version: 14.18.0
+          node-version: 16.14.0
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build
@@ -48,7 +48,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           cache: yarn
-          node-version: 14.18.0
+          node-version: 16.14.0
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Set git identity

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14.18.0
+          node-version: 16.14.0
           cache: yarn
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           cache: yarn
-          node-version: 14.18.0
+          node-version: 16.14.0
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Prepare Release
@@ -130,7 +130,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           always-auth: true
-          node-version: 14.18.0
+          node-version: 16.14.0
           registry-url: https://registry.npmjs.org/
       - name: Federate to AWS
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14.18.0
+          node-version: 16.14.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.github/workflows/upgrade-maintenance-v5.0.yml
+++ b/.github/workflows/upgrade-maintenance-v5.0.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14.18.0
+          node-version: 16.14.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Back-port projenrc changes from main

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -30,7 +30,7 @@
     },
     {
       "name": "@types/node",
-      "version": "^14",
+      "version": "^16",
       "type": "build"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -30,7 +30,7 @@ const project = new typescript.TypeScriptProject({
 
   autoDetectBin: true,
 
-  minNodeVersion: '14.18.0',
+  minNodeVersion: '16.14.0',
   tsconfig: {
     compilerOptions: {
       // @see https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/glob": "^8.1.0",
     "@types/jest": "^29.5.2",
     "@types/lockfile": "^1.0.2",
-    "@types/node": "^14",
+    "@types/node": "^16",
     "@types/semver": "^7.5.0",
     "@types/tar": "^6.1.5",
     "@typescript-eslint/eslint-plugin": "^5",
@@ -83,7 +83,7 @@
     "yargs": "^17.7.2"
   },
   "engines": {
-    "node": ">= 14.18.0"
+    "node": ">= 16.14.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1216,10 +1216,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.3.1.tgz#e8a83f1aa8b649377bb1fb5d7bac5cb90e784dfe"
   integrity sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg==
 
-"@types/node@^14":
-  version "14.18.51"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.51.tgz#cb90935b89c641201c3d07a595c3e22d1cfaa417"
-  integrity sha512-P9bsdGFPpVtofEKlhWMVS2qqx1A/rt9QBfihWlklfHHpUpjtYse5AzFz6j4DWrARLYh6gRnw9+5+DJcrq3KvBA==
+"@types/node@^16":
+  version "16.18.36"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.36.tgz#0db5d7efc4760d36d0d1d22c85d1a53accd5dc27"
+  integrity sha512-8egDX8dE50XyXWH6C6PRCNkTP106DuUrvdrednFouDSmCi7IOvrqr0frznfZaHifHH/3aq/7a7v9N4wdXMqhBQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"


### PR DESCRIPTION
The  upgrade-maintenance-v5.0 workflow is failing with the message:

```
error get-stream@7.0.0: The engine "node" is incompatible with this module. Expected version ">=16". Got "14.18.0"
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0