### PR TITLE
chore: upgrade workflow fails on install:ci

### DIFF
--- a/.github/workflows/upgrade-maintenance-v5.0.yml
+++ b/.github/workflows/upgrade-maintenance-v5.0.yml
@@ -26,7 +26,7 @@ jobs:
         run: yarn install --check-files --frozen-lockfile
       - name: Back-port projenrc changes from main
         env:
-          CI: "true"
+          CI: "false"
         run: git fetch origin main && git checkout FETCH_HEAD -- .projenrc.ts projenrc README.md && yarn projen
       - name: Upgrade dependencies
         run: npx projen upgrade

--- a/projenrc/upgrade-dependencies.ts
+++ b/projenrc/upgrade-dependencies.ts
@@ -264,7 +264,11 @@ export class UpgradeDependencies extends Component {
       ...(branch && branch !== 'main'
         ? [
             {
-              env: { CI: 'true' },
+              env: {
+                // Important: this ensures `yarn projen` runs `yarn install` and not `yarn install:ci` so it can update
+                // the yarn.lock file.
+                CI: 'false',
+              },
               name: 'Back-port projenrc changes from main',
               run: 'git fetch origin main && git checkout FETCH_HEAD -- .projenrc.ts projenrc README.md && yarn projen',
             },


### PR DESCRIPTION
Set `CI=false` in the upgrade workflow step that updates the `.projenrc` files so that `yarn projen` runs the `install` task and not the `install:ci` task (which does not allow locfile updates).



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0