### PR TITLE
fix: unnecessary down-leveled declarations written

### DIFF
--- a/src/downlevel-dts.ts
+++ b/src/downlevel-dts.ts
@@ -185,7 +185,7 @@ function semanticallyEqualDeclarations(left: string, right: string): boolean {
     // TypeScript may emit duplicated reference declarations... which are absent from Downlevel-DTS' output...
     // https://github.com/microsoft/TypeScript/issues/48143
     const REFERENCES_TYPES_NODE = '/// <reference types="node" />';
-    if (normalized.startsWith(`${REFERENCES_TYPES_NODE}\n${REFERENCES_TYPES_NODE}`)) {
+    while (normalized.startsWith(`${REFERENCES_TYPES_NODE}\n${REFERENCES_TYPES_NODE}`)) {
       normalized = normalized.slice(REFERENCES_TYPES_NODE.length + 1);
     }
 


### PR DESCRIPTION
The test that assesses whether down-leveled declarations are necessary or not accounted for the possible presence of duplicated references to `node` types being injected by the TypeScript compiler (microsoft/TypeScript#48143), however in some cases the reference is present more than twice, which was not correctly accounted for; resulting in emission of redundant down-level declarations.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0