### PR TITLE
chore: fix upgrade-dependencies task

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -264,7 +264,7 @@
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade "
+          "exec": "yarn upgrade"
         },
         {
           "exec": "npx projen"

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -264,7 +264,7 @@
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade"
+          "exec": "yarn upgrade "
         },
         {
           "exec": "npx projen"

--- a/projenrc/upgrade-dependencies.ts
+++ b/projenrc/upgrade-dependencies.ts
@@ -328,7 +328,7 @@ export class UpgradeDependencies extends Component {
   private renderUpgradePackagesCommand(include?: string[]): string {
     function upgradePackages(command: string) {
       return () => {
-        return `${command} ${(include ?? []).join(' ')}`;
+        return `${command} ${(include ?? []).join(' ')}`.trim();
       };
     }
 


### PR DESCRIPTION
We do not use the `exclude` keyword and likely will not for the foreseeable future. Just dropping it for now. We will have to re-implement that if we need it but I don't see why we would -- this decision was also made in projen: https://github.com/projen/projen/pull/2845/files. This continues work started because projen had breaking changes.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0