### PR TITLE
chore: fix failing tsconfig validator prop test

### DIFF
--- a/test/tsconfig/validator.test.ts
+++ b/test/tsconfig/validator.test.ts
@@ -179,6 +179,44 @@ describe('Built-in matchers', () => {
       );
     });
   });
+
+  describe('Match.TRUE', () => {
+    test('pass', () => {
+      expect(Match.TRUE(true)).toBe(true);
+    });
+
+    test('fail', () => {
+      expect(Match.TRUE(false)).toBe(false);
+    });
+  });
+
+  describe('Match.FALSE', () => {
+    test('pass', () => {
+      expect(Match.FALSE(false)).toBe(true);
+    });
+
+    test('fail', () => {
+      expect(Match.FALSE(true)).toBe(false);
+    });
+  });
+
+  describe('Match.MISSING', () => {
+    test('pass', () => {
+      expect(Match.MISSING(undefined)).toBe(true);
+      expect(Match.MISSING(null)).toBe(true);
+    });
+
+    test('fail', () => {
+      fc.assert(
+        fc.property(
+          fc.anything().filter((v) => !(v === undefined || v === null)),
+          (actual) => {
+            return !Match.MISSING(actual);
+          },
+        ),
+      );
+    });
+  });
 });
 
 describe('Object Validator', () => {


### PR DESCRIPTION
There was a proptest that failed in our test pipeline:

```
FAIL test/tsconfig/validator.test.ts
  ● Built-in matchers › Match.arrEq › pass

    Property failed after 63 tests
    { seed: -1990728707, path: "62:2:64", endOnFailure: true }
    Counterexample: [[[Number.NaN],[Number.NaN]]]
```
To fix this, I refactored the `looseEqual` helper. This also made some of the matcher code simpler.
Also added a few missing tests for some matchers.

In practice this is probably not very relevant, so I made this a chore.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0