### PR TITLE
chore: restore ability to release maintenance version lines

### DIFF
--- a/.github/workflows/auto-tag-dev-v5.2.yml
+++ b/.github/workflows/auto-tag-dev-v5.2.yml
@@ -56,4 +56,4 @@ jobs:
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
       - name: Tag PreRelease
-        run: yarn tag-release --idempotent --no-sign --push --prerelease=dev
+        run: yarn tag-release --idempotent --no-sign --push --prerelease=dev --release-line=5.2

--- a/.github/workflows/auto-tag-dev-v5.3.yml
+++ b/.github/workflows/auto-tag-dev-v5.3.yml
@@ -56,4 +56,4 @@ jobs:
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
       - name: Tag PreRelease
-        run: yarn tag-release --idempotent --no-sign --push --prerelease=dev
+        run: yarn tag-release --idempotent --no-sign --push --prerelease=dev --release-line=5.3

--- a/.github/workflows/auto-tag-dev.yml
+++ b/.github/workflows/auto-tag-dev.yml
@@ -56,4 +56,4 @@ jobs:
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
       - name: Tag PreRelease
-        run: yarn tag-release --idempotent --no-sign --push --prerelease=dev
+        run: yarn tag-release --idempotent --no-sign --push --prerelease=dev --release-line=5.4

--- a/.github/workflows/auto-tag-releases-v5.2.yml
+++ b/.github/workflows/auto-tag-releases-v5.2.yml
@@ -56,4 +56,4 @@ jobs:
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
       - name: Tag Release
-        run: "yarn tag-release --idempotent --no-sign --push "
+        run: yarn tag-release --idempotent --no-sign --push  --release-line=5.2

--- a/.github/workflows/auto-tag-releases-v5.2.yml
+++ b/.github/workflows/auto-tag-releases-v5.2.yml
@@ -56,4 +56,4 @@ jobs:
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
       - name: Tag Release
-        run: yarn tag-release --idempotent --no-sign --push  --release-line=5.2
+        run: yarn tag-release --idempotent --no-sign --push --release-line=5.2

--- a/.github/workflows/auto-tag-releases-v5.3.yml
+++ b/.github/workflows/auto-tag-releases-v5.3.yml
@@ -56,4 +56,4 @@ jobs:
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
       - name: Tag Release
-        run: yarn tag-release --idempotent --no-sign --push  --release-line=5.3
+        run: yarn tag-release --idempotent --no-sign --push --release-line=5.3

--- a/.github/workflows/auto-tag-releases-v5.3.yml
+++ b/.github/workflows/auto-tag-releases-v5.3.yml
@@ -56,4 +56,4 @@ jobs:
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
       - name: Tag Release
-        run: "yarn tag-release --idempotent --no-sign --push "
+        run: yarn tag-release --idempotent --no-sign --push  --release-line=5.3

--- a/.github/workflows/auto-tag-releases.yml
+++ b/.github/workflows/auto-tag-releases.yml
@@ -56,4 +56,4 @@ jobs:
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
       - name: Tag Release
-        run: "yarn tag-release --idempotent --no-sign --push "
+        run: yarn tag-release --idempotent --no-sign --push  --release-line=5.4

--- a/.github/workflows/auto-tag-releases.yml
+++ b/.github/workflows/auto-tag-releases.yml
@@ -56,4 +56,4 @@ jobs:
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
       - name: Tag Release
-        run: yarn tag-release --idempotent --no-sign --push  --release-line=5.4
+        run: yarn tag-release --idempotent --no-sign --push --release-line=5.4

--- a/.github/workflows/upgrade-maintenance-v5.2.yml
+++ b/.github/workflows/upgrade-maintenance-v5.2.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Back-port projenrc changes from main
         env:
           CI: "false"
-        run: git fetch origin main && git checkout FETCH_HEAD -- .projenrc.ts projenrc README.md && yarn projen
+        run: git fetch origin main && git checkout FETCH_HEAD -- README.md && yarn projen
       - name: Upgrade dependencies
         run: npx projen upgrade
       - name: Find mutations

--- a/.github/workflows/upgrade-maintenance-v5.3.yml
+++ b/.github/workflows/upgrade-maintenance-v5.3.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Back-port projenrc changes from main
         env:
           CI: "false"
-        run: git fetch origin main && git checkout FETCH_HEAD -- .projenrc.ts projenrc README.md && yarn projen
+        run: git fetch origin main && git checkout FETCH_HEAD -- README.md && yarn projen
       - name: Upgrade dependencies
         run: npx projen upgrade
       - name: Find mutations

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -274,11 +274,13 @@ new BuildWorkflow(project);
 const supported = new SupportPolicy(project);
 const releases = new ReleaseWorkflow(project)
   .autoTag({
+    releaseLine: SUPPORT_POLICY.current,
     preReleaseId: 'dev',
     runName: 'Auto-Tag Prerelease (default branch)',
     schedule: '0 0 * * 0,2-6', // Tuesday though sundays at midnight
   })
   .autoTag({
+    releaseLine: SUPPORT_POLICY.current,
     runName: 'Auto-Tag Release (default branch)',
     schedule: '0 0 * * 1', // Mondays at midnight
   });
@@ -291,6 +293,7 @@ for (const [version, branch] of Object.entries(supported.activeBranches(false)))
   const tag = `v${version}`;
   releases
     .autoTag({
+      releaseLine: version,
       preReleaseId: 'dev',
       runName: `Auto-Tag Prerelease (${tag})`,
       schedule: `0 ${hour} * * 0,2-6`, // Tuesday though sundays
@@ -298,6 +301,7 @@ for (const [version, branch] of Object.entries(supported.activeBranches(false)))
       nameSuffix: tag,
     })
     .autoTag({
+      releaseLine: version,
       runName: `Auto-Tag Release (${tag})`,
       schedule: `0 ${hour} * * 1`, // Mondays
       branch,

--- a/projenrc/release.ts
+++ b/projenrc/release.ts
@@ -292,6 +292,11 @@ class TagReleaseTask {
 
 interface AutoTagWorkflowProps {
   /**
+   * The version used as the tagging base
+   */
+  readonly releaseLine: string;
+
+  /**
    * The branch on which to trigger this AutoTagWorkflow.
    *
    * @default - the repository's default branch
@@ -382,7 +387,7 @@ class AutoTagWorkflow {
           name: `Tag ${props.preReleaseId ? 'PreRelease' : 'Release'}`,
           run: `yarn tag-release --idempotent --no-sign --push ${
             props.preReleaseId ? `--prerelease=${props.preReleaseId}` : ''
-          }`,
+          } --release-line=${props.releaseLine}`,
         },
       ],
     });

--- a/projenrc/release.ts
+++ b/projenrc/release.ts
@@ -386,8 +386,8 @@ class AutoTagWorkflow {
         {
           name: `Tag ${props.preReleaseId ? 'PreRelease' : 'Release'}`,
           run: `yarn tag-release --idempotent --no-sign --push ${
-            props.preReleaseId ? `--prerelease=${props.preReleaseId}` : ''
-          } --release-line=${props.releaseLine}`,
+            props.preReleaseId ? `--prerelease=${props.preReleaseId} ` : ''
+          }--release-line=${props.releaseLine}`,
         },
       ],
     });

--- a/projenrc/tag-release.ts
+++ b/projenrc/tag-release.ts
@@ -15,6 +15,7 @@ async function main(): Promise<void> {
     remote,
     sign,
     verbose,
+    releaseLine,
   } = await yargs
     .scriptName('npx projen tag-release')
     .option('idempotent', {
@@ -62,10 +63,21 @@ async function main(): Promise<void> {
       desc: 'Do not actually create a tag, just determine what it would be',
       default: false,
     })
+    .option('release-line', {
+      alias: 'r',
+      type: 'string',
+      desc: 'The version line for this release. This will be checked against the actual available typescript version and fail if they do not match. If not provided the current typescript version will be released.',
+      default: versionMajorMinor,
+    })
     .help().argv;
 
   if (verbose) {
-    console.debug(`Current release line: ${versionMajorMinor}`);
+    console.debug(`Expected release line: ${releaseLine}`);
+    console.debug(`Detected release line: ${versionMajorMinor}`);
+  }
+
+  if (releaseLine !== versionMajorMinor) {
+    throw new Error(`Release line mismatch: expected ${releaseLine}, got ${versionMajorMinor}`);
   }
 
   // Shell out to a git command and ensure it returns successfully, and returns

--- a/projenrc/upgrade-dependencies.ts
+++ b/projenrc/upgrade-dependencies.ts
@@ -261,7 +261,7 @@ export class UpgradeDependencies extends Component {
                 CI: 'false',
               },
               name: 'Back-port projenrc changes from main',
-              run: 'git fetch origin main && git checkout FETCH_HEAD -- .projenrc.ts projenrc README.md && yarn projen',
+              run: 'git fetch origin main && git checkout FETCH_HEAD -- README.md && yarn projen',
             },
           ]
         : []),


### PR DESCRIPTION
This repo was using an automatic backport feature for repository config. As part of daily upgrades, the projen config would be checked out from `main` and applied to maintenance branches. However because we also defined the current version in this config, this inadvertently changed the current version for maintenance branches as well! In practice that meant that the release tagging workflow tagged the wrong release lines.

This fix does two things: 
- Disable the automatic backport of configuration in favor of the new, explicit label based backport feature (see it in action on this PR!)
- Add an explicit release line option to the tagging workflow, that will be compared against the detected TypeScript version and fail if they don't match.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0