### PR TITLE
fix(docs): remove newlines on windows by replacing carriage return `\r\n` with spaces

### DIFF
--- a/src/docs.ts
+++ b/src/docs.ts
@@ -201,7 +201,7 @@ export function splitSummary(docBlock: string | undefined): [string | undefined,
  * Replace newlines with spaces for use in tables
  */
 function noNewlines(s: string) {
-  return s.replace(/\n/g, ' ');
+  return s.replace(/\r?\n/g, ' ');
 }
 
 function endWithPeriod(s: string) {


### PR DESCRIPTION
When removing newlines in doc blocks, jsii it's leaving `\r` character on Windows. This appeared when doing https://github.com/projen/projen/pull/3582

The workaround is to replace the string in projects depending on jsii like projen. I did [a workaround here](https://github.com/projen/projen/pull/3582/commits/d6d8e54a2b4abcc9152d0b3c11eef4fcc73068bd).

Some examples of output from `console.log(util.inspect(myVar))` can be seen in this job, where the existing `\r` creates a newline when is not expected there and causes Node to throw `SyntaxError`s when using [`vm.runInContext`](https://github.com/projen/projen/blob/70b287e22b9913019a2a1113bc091e3cf2335bdb/src/projects.ts#L157)

## Received error `SyntaxError: Unexpected token '('`
https://github.com/projen/projen/actions/runs/9341376021/job/25708063745?pr=3582#step:6:467
```
'const projectmq7tm0jg26g = new awscdk.AwsCdkJavaApp({\n' +
  '  __new__: {"args":{"artifactId":"my-app","cdkVersion":"2.1.0","groupId":"org.acme","mainClass":"org.acme.MyApp","name":"my-project","version":"0.1.0"},"fqn":"projen.awscdk.AwsCdkJavaApp","comments":"featured"},\n' +
  '  artifactId: "my-app",\n' +
  '  cdkVersion: "2.1.0",\n' +
  '  groupId: "org.acme",\n' +
  '  mainClass: "org.acme.MyApp",\n' +
  '  name: "my-project",\n' +
  '  outdir: "C:\\\\Users\\\\RUNNER~1\\\\AppData\\\\Local\\\\Temp\\\\projen-test-LaFJWR\\\\my-project",\n' +
  '  version: "0.1.0",\n' +
  '\n' +
  '  // deps: [],                /* List of runtime dependencies for this project. */\n' +
  '  // description: undefined,  /* Description of a project is always good. */\n' +
  '  // parentPom: undefined,    /* A Parent Pom can be used to have a child project inherit\r properties/plugins/ect in order to reduce duplication and keep standards\r across a large amount of repos. */\n' +
  '  // testDeps: [],            /* List of test dependencies for this project. */\n' +
  '  // url: undefined,          /* The URL, like the name, is not required. */\n' +
  '});'
```

## Received error `SyntaxError: Unexpected token '/`
https://github.com/projen/projen/actions/runs/9341376021/job/25708063745?pr=3582#step:6:888
```
'const projectczoq6zx83pe = new awscdk.AwsCdkPythonApp({\n' +
  '  __new__: {"args":{"authorEmail":"my@user.email.com","authorName":"My User Name","cdkVersion":"2.1.0","moduleName":"my_project","name":"my-project","version":"0.1.0"},"fqn":"projen.awscdk.AwsCdkPythonApp","comments":"featured"},\n' +
  '  authorEmail: "my@user.email.com",\n' +
  '  authorName: "My User Name",\n' +
  '  cdkVersion: "2.1.0",\n' +
  '  moduleName: "my_project",\n' +
  '  name: "my-project",\n' +
  '  outdir: "C:\\\\Users\\\\RUNNER~1\\\\AppData\\\\Local\\\\Temp\\\\projen-test-SQUjk7\\\\my-project",\n' +
  '  version: "0.1.0",\n' +
  '\n' +
  '  // deps: [],                /* List of runtime dependencies for this project. */\n' +
  '  // description: undefined,  /* A short description of the package. */\n' +
  '  // devDeps: [],             /* List of dev dependencies for this project. */\n' +
  '  // pip: undefined,          /* Use pip with a requirements.txt file to track project dependencies. */\n' +
  '  // poetry: false,           /* Use poetry to manage your project dependencies, virtual environment, and\r (optional) packaging/publishing. */\n' +
  '  // pytest: true,            /* Include pytest tests. */\n' +
  '  // setuptools: undefined,   /* Use setuptools with a setup.py script for packaging and publishing. */\n' +
  '  // venv: undefined,         /* Use venv to manage a virtual environment for installing dependencies inside. */\n' +
  '});'
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0