### PR TITLE
chore: allow to write id-token to authenticate with OIDC

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -299,7 +299,6 @@ jobs:
       jsii-13: ${{ steps.run.outputs.jsii-13 }}
       tsc-13: ${{ steps.run.outputs.tsc-13 }}
       jsii-14: ${{ steps.run.outputs.jsii-14 }}
-        id-token: write #
       tsc-14: ${{ steps.run.outputs.tsc-14 }}
       jsii-15: ${{ steps.run.outputs.jsii-15 }}
       tsc-15: ${{ steps.run.outputs.tsc-15 }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -267,6 +267,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: read
     outputs:
       jsii-0: ${{ steps.run.outputs.jsii-0 }}
@@ -298,6 +299,7 @@ jobs:
       jsii-13: ${{ steps.run.outputs.jsii-13 }}
       tsc-13: ${{ steps.run.outputs.tsc-13 }}
       jsii-14: ${{ steps.run.outputs.jsii-14 }}
+        id-token: write #
       tsc-14: ${{ steps.run.outputs.tsc-14 }}
       jsii-15: ${{ steps.run.outputs.jsii-15 }}
       tsc-15: ${{ steps.run.outputs.tsc-15 }}


### PR DESCRIPTION
Fixes error https://github.com/aws/jsii-compiler/actions/runs/9429669040/job/26020375687?pr=1058#step:3:12

```
It looks like you might be trying to authenticate with OIDC. Did you mean to set the `id-token` permission? If you are not trying to authenticate with OIDC and the action is working successfully, you can ignore this message.
Error: Credentials could not be loaded, please check your action inputs: Could not load credentials from any providers
```


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0