### PR TITLE
chore: use latest node versions

### DIFF
--- a/.github/workflows/auto-tag-dev-v5.2.yml
+++ b/.github/workflows/auto-tag-dev-v5.2.yml
@@ -21,10 +21,10 @@ jobs:
           repository: ${{ github.repository }}
           ref: maintenance/v5.2
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: 18.12.0
+          node-version: "18"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build
@@ -45,10 +45,10 @@ jobs:
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: ${{ needs.pre-flight.outputs.sha }}
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: 18.12.0
+          node-version: "18"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Set git identity

--- a/.github/workflows/auto-tag-dev-v5.3.yml
+++ b/.github/workflows/auto-tag-dev-v5.3.yml
@@ -21,10 +21,10 @@ jobs:
           repository: ${{ github.repository }}
           ref: maintenance/v5.3
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: 18.12.0
+          node-version: "18"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build
@@ -45,10 +45,10 @@ jobs:
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: ${{ needs.pre-flight.outputs.sha }}
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: 18.12.0
+          node-version: "18"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Set git identity

--- a/.github/workflows/auto-tag-dev.yml
+++ b/.github/workflows/auto-tag-dev.yml
@@ -21,10 +21,10 @@ jobs:
           repository: ${{ github.repository }}
           ref: ${{ github.ref }}
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: 18.12.0
+          node-version: "18"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build
@@ -45,10 +45,10 @@ jobs:
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: ${{ needs.pre-flight.outputs.sha }}
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: 18.12.0
+          node-version: "18"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Set git identity

--- a/.github/workflows/auto-tag-releases-v5.2.yml
+++ b/.github/workflows/auto-tag-releases-v5.2.yml
@@ -21,10 +21,10 @@ jobs:
           repository: ${{ github.repository }}
           ref: maintenance/v5.2
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: 18.12.0
+          node-version: "18"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build
@@ -45,10 +45,10 @@ jobs:
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: ${{ needs.pre-flight.outputs.sha }}
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: 18.12.0
+          node-version: "18"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Set git identity

--- a/.github/workflows/auto-tag-releases-v5.3.yml
+++ b/.github/workflows/auto-tag-releases-v5.3.yml
@@ -21,10 +21,10 @@ jobs:
           repository: ${{ github.repository }}
           ref: maintenance/v5.3
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: 18.12.0
+          node-version: "18"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build
@@ -45,10 +45,10 @@ jobs:
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: ${{ needs.pre-flight.outputs.sha }}
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: 18.12.0
+          node-version: "18"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Set git identity

--- a/.github/workflows/auto-tag-releases.yml
+++ b/.github/workflows/auto-tag-releases.yml
@@ -21,10 +21,10 @@ jobs:
           repository: ${{ github.repository }}
           ref: ${{ github.ref }}
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: 18.12.0
+          node-version: "18"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build
@@ -45,10 +45,10 @@ jobs:
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: ${{ needs.pre-flight.outputs.sha }}
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: 18.12.0
+          node-version: "18"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Set git identity

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           lfs: true
           ref: ${{ github.ref }}
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: yarn
       - name: Cache build outputs
@@ -115,7 +115,7 @@ jobs:
           name: build-output
           path: ${{ github.workspace }}
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
@@ -158,9 +158,9 @@ jobs:
           name: build-output
           path: ${{ github.workspace }}
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.12.0
+          node-version: "18"
           cache: yarn
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -180,7 +180,7 @@ jobs:
       CI: "true"
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Download Artifact
@@ -235,7 +235,7 @@ jobs:
       CI: "true"
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with: {}
       - name: Download Artifact
         uses: actions/download-artifact@v3
@@ -313,7 +313,7 @@ jobs:
       CI: "true"
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with: {}
       - name: Download artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,10 @@ jobs:
           repository: ${{ github.repository }}
           ref: ${{ github.ref }}
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: 18.12.0
+          node-version: "18"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Prepare Release
@@ -127,10 +127,10 @@ jobs:
         with:
           name: release-package
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           always-auth: true
-          node-version: 18.12.0
+          node-version: "18"
           registry-url: https://registry.npmjs.org/
       - name: Federate to AWS
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.12.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.github/workflows/upgrade-maintenance-v5.2.yml
+++ b/.github/workflows/upgrade-maintenance-v5.2.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.12.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Back-port projenrc changes from main

--- a/.github/workflows/upgrade-maintenance-v5.3.yml
+++ b/.github/workflows/upgrade-maintenance-v5.3.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.12.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Back-port projenrc changes from main

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -103,6 +103,7 @@ const project = new typescript.TypeScriptProject({
   buildWorkflow: false, // We have our own build workflow (need matrix test)
   release: false, // We have our own release workflow
   defaultReleaseBranch: 'main',
+  workflowNodeVersion: 'lts/*', // upgrade workflows should run on latest lts version
 
   autoApproveUpgrades: true,
   autoApproveOptions: {

--- a/projenrc/build-workflow.ts
+++ b/projenrc/build-workflow.ts
@@ -40,6 +40,8 @@ export class BuildWorkflow {
       });
     }
 
+    const nodeVersion = project.minNodeVersion?.split('.', 1).at(0) ?? 'lts/*';
+
     wf.addJobs({
       'build': {
         env: { CI: 'true' },
@@ -189,7 +191,7 @@ export class BuildWorkflow {
           },
           {
             name: 'Setup Node.js',
-            uses: 'actions/setup-node@v3',
+            uses: 'actions/setup-node@v4',
             with: {
               'node-version': '${{ matrix.node-version }}',
               'cache': 'yarn',
@@ -234,9 +236,9 @@ export class BuildWorkflow {
           },
           {
             name: 'Setup Node.js',
-            uses: 'actions/setup-node@v3',
+            uses: 'actions/setup-node@v4',
             with: {
-              'node-version': project.minNodeVersion,
+              'node-version': nodeVersion,
               'cache': 'yarn',
             },
           },

--- a/projenrc/common.ts
+++ b/projenrc/common.ts
@@ -34,7 +34,7 @@ export function ACTIONS_SETUP_NODE(
 ): github.workflows.JobStep {
   return {
     name: 'Setup Node.js',
-    uses: 'actions/setup-node@v3',
+    uses: 'actions/setup-node@v4',
     with: {
       'cache': cache || undefined,
       'node-version': nodeVersion,

--- a/projenrc/release.ts
+++ b/projenrc/release.ts
@@ -22,6 +22,8 @@ export class ReleaseWorkflow {
 
     release.on({ push: { tags: ['v*.*.*'] } });
 
+    const nodeVersion = project.minNodeVersion?.split('.', 1).at(0) ?? 'lts/*';
+
     const releasePackageName = 'release-package';
     const publishTarget = 'publish-target';
     const federateToAwsStep: github.workflows.JobStep = {
@@ -52,7 +54,7 @@ export class ReleaseWorkflow {
       runsOn: ['ubuntu-latest'],
       steps: [
         ACTIONS_CHECKOUT(),
-        ACTIONS_SETUP_NODE(project.minNodeVersion),
+        ACTIONS_SETUP_NODE(nodeVersion),
         YARN_INSTALL(),
         {
           name: 'Prepare Release',
@@ -212,7 +214,7 @@ export class ReleaseWorkflow {
           ...ACTIONS_SETUP_NODE(),
           with: {
             'always-auth': true,
-            'node-version': project.minNodeVersion,
+            'node-version': nodeVersion,
             'registry-url': `https://registry.npmjs.org/`,
           },
         },
@@ -337,6 +339,7 @@ interface AutoTagWorkflowProps {
 
 class AutoTagWorkflow {
   public constructor(project: typescript.TypeScriptProject, name: string, props: AutoTagWorkflowProps) {
+    const nodeVersion = project.minNodeVersion?.split('.', 1).at(0) ?? 'lts/*';
     const workflow = project.github!.addWorkflow(name);
     workflow.runName = props.runName;
     workflow.on({
@@ -362,7 +365,7 @@ class AutoTagWorkflow {
       permissions: { contents: github.workflows.JobPermission.READ },
       steps: [
         ACTIONS_CHECKOUT(props.branch),
-        ACTIONS_SETUP_NODE(project.minNodeVersion),
+        ACTIONS_SETUP_NODE(nodeVersion),
         YARN_INSTALL(),
         { name: 'Build', run: 'yarn build' },
         { id: 'git', name: 'Identify git SHA', run: 'echo sha=$(git rev-parse HEAD) >> $GITHUB_OUTPUT' },
@@ -375,7 +378,7 @@ class AutoTagWorkflow {
       permissions: {},
       steps: [
         ACTIONS_CHECKOUT('${{ needs.pre-flight.outputs.sha }}', { token: '${{ secrets.PROJEN_GITHUB_TOKEN }}' }),
-        ACTIONS_SETUP_NODE(project.minNodeVersion),
+        ACTIONS_SETUP_NODE(nodeVersion),
         YARN_INSTALL(),
         {
           name: 'Set git identity',


### PR DESCRIPTION
upgrade workflows should use the latest lts version of node
build workflow should use the latest available version of the current major version for bug fixes

Backport from jsii-rosetta.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0