### PR TITLE
chore: do not publish benchmark metrics from forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -418,7 +418,7 @@ jobs:
           fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary.join("\n"), "utf-8");
           EOF
       - name: Authenticate Via OIDC Role
-        if: github.ref == 'refs/heads/main'
+        if: github.event.repository.fork == false && github.ref == 'refs/heads/main'
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: us-east-1
@@ -427,7 +427,7 @@ jobs:
           role-session-name: github-diff-action@cdk-ops
           output-credentials: true
       - name: Publish Metrics
-        if: github.ref == 'refs/heads/main'
+        if: github.event.repository.fork == false && github.ref == 'refs/heads/main'
         run: |-
           aws cloudwatch put-metric-data --metric-name TSC-average --namespace JsiiPerformance --value ${{ steps.output_summary.outputs.duration-tsc }}
           aws cloudwatch put-metric-data --metric-name JSII-average --namespace JsiiPerformance --value ${{ steps.output_summary.outputs.duration-jsii }}

--- a/projenrc/benchmark-test.ts
+++ b/projenrc/benchmark-test.ts
@@ -132,7 +132,7 @@ export class BenchmarkTest {
           },
           {
             name: 'Authenticate Via OIDC Role',
-            if: `github.ref == 'refs/heads/main'`,
+            if: `github.event.repository.fork == false && github.ref == 'refs/heads/main'`,
             uses: 'aws-actions/configure-aws-credentials@v4',
             with: {
               'aws-region': 'us-east-1',
@@ -144,7 +144,7 @@ export class BenchmarkTest {
           },
           {
             name: 'Publish Metrics',
-            if: `github.ref == 'refs/heads/main'`,
+            if: `github.event.repository.fork == false && github.ref == 'refs/heads/main'`,
             run: [
               'aws cloudwatch put-metric-data --metric-name TSC-average --namespace JsiiPerformance --value ${{ steps.output_summary.outputs.duration-tsc }}',
               'aws cloudwatch put-metric-data --metric-name JSII-average --namespace JsiiPerformance --value ${{ steps.output_summary.outputs.duration-jsii }}',


### PR DESCRIPTION
Adds check to not publish the benchmark metrics from a fork.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0