### PR TITLE
fix(docs): split paragraphs by both Unix and Windows newlines

### DIFF
--- a/src/docs.ts
+++ b/src/docs.ts
@@ -227,7 +227,7 @@ const SUMMARY_MAX_WORDS = 20;
  * long, we'll take the first sentence (terminated by a punctuation).
  */
 function summaryLine(str: string) {
-  const paras = str.split('\n\n');
+  const paras = str.split(/(\r?\n){2}/);
   if (paras.length > 1 && paras[0].split(' ').length < SUMMARY_MAX_WORDS) {
     return paras[0];
   }


### PR DESCRIPTION
Similar to https://github.com/aws/jsii-compiler/pull/1058, the Windows newline character wasn't matched and handled accordingly.

I found the problem in [this Github run](https://github.com/projen/projen/actions/runs/9536528729/job/26283592671?pr=3582#step:6:2043) which gives errors in snapshots, like the one below

```json
{
              "default": "- No minimum version is being enforced",
    -         "docs": "Minimal Major version to release.",
    +         "docs": "Minimal Major version to release   This can be useful to set to 1, as breaking changes before the 1.x major release are not incrementing the major version number.  Can not be set together with `majorVersion`.",
              "featured": false,
              "fullType": {
                "primitive": "number",
 },
```

I tested that the changed works OK by packaging and installing jsii locally, getting the following correct output in the local projen `.jsii` file.
```json
{
          "abstract": true,
          "docs": {
            "default": "- No minimum version is being enforced",
            "remarks": "This can be useful to set to 1, as breaking changes before the 1.x major\nrelease are not incrementing the major version number.\n\nCan not be set together with `majorVersion`.",
            "stability": "experimental",
            "summary": "Minimal Major version to release."
          },
          "immutable": true,
          "locationInModule": {
            "filename": "src/release/release.ts",
            "line": 123
          },
          "name": "minMajorVersion",
          "optional": true,
          "type": {
            "primitive": "number"
          }
},
```

`.jsii` inventory file before the change : [before_change_jsii.json](https://github.com/user-attachments/files/15935939/before_change_jsii.json)

`.jsii` inventory file after the change: [after_change_jsii.json](https://github.com/user-attachments/files/15935940/after_change_jsii.json)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0