### PR TITLE
chore: fix version line in JSII benchmark metric dimension

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -455,7 +455,7 @@ jobs:
                           "Dimensions": [
                             {
                               "Name": "TscVersion",
-                              "Value": "${{ steps.version.outputs.release-line }}
+                              "Value": "${{ env.release-line }}
                               "
                             }
                           ]
@@ -466,7 +466,7 @@ jobs:
                           "Dimensions": [
                             {
                               "Name": "JsiiVersion",
-                              "Value": "${{ steps.version.outputs.release-line }}"
+                              "Value": "${{ env.release-line }}"
                             }
                           ]
                         },
@@ -476,7 +476,7 @@ jobs:
                           "Dimensions": [
                             {
                               "Name": "JsiiVersion",
-                              "Value": "${{ steps.version.outputs.release-line }}
+                              "Value": "${{ env.release-line }}
                               "
                             }
                           ]

--- a/projenrc/benchmark-test.ts
+++ b/projenrc/benchmark-test.ts
@@ -175,7 +175,7 @@ export class BenchmarkTest {
                 "Dimensions": [
                   {
                     "Name": "TscVersion",
-                    "Value": "\${{ steps.version.outputs.release-line }}
+                    "Value": "\${{ env.release-line }}
                     "
                   }
                 ]
@@ -186,7 +186,7 @@ export class BenchmarkTest {
                 "Dimensions": [
                   {
                     "Name": "JsiiVersion",
-                    "Value": "\${{ steps.version.outputs.release-line }}"
+                    "Value": "\${{ env.release-line }}"
                   }
                 ]
               },
@@ -196,7 +196,7 @@ export class BenchmarkTest {
                 "Dimensions": [
                   {
                     "Name": "JsiiVersion",
-                    "Value": "\${{ steps.version.outputs.release-line }}
+                    "Value": "\${{ env.release-line }}
                     "
                   }
                 ]


### PR DESCRIPTION
Workflow has been [broken](https://github.com/aws/jsii-compiler/actions/runs/9637586787/job/26577222425#step:5:90) as no value has been passed in to the metric dimension.

Tested it works [here](https://github.com/aws/jsii-compiler/actions/runs/9648974164/job/26611821291#step:5:8)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0