### PR TITLE
chore: fix typo in jsii slowdown metric version dimension

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -476,7 +476,7 @@ jobs:
                           "Dimensions": [
                             {
                               "Name": "JsiiVersion",
-                              "Value": "${{ needs.build.outputs.release-line }}}"
+                              "Value": "${{ needs.build.outputs.release-line }}"
                             }
                           ]
                         }

--- a/projenrc/benchmark-test.ts
+++ b/projenrc/benchmark-test.ts
@@ -184,7 +184,7 @@ export class BenchmarkTest {
                 "Dimensions": [
                   {
                     "Name": "JsiiVersion",
-                    "Value": "\${{ needs.build.outputs.release-line }}}"
+                    "Value": "\${{ needs.build.outputs.release-line }}"
                   }
                 ]
               }


### PR DESCRIPTION
Fixes this typo:

<img width="521" alt="Screenshot 2024-07-08 at 11 06 50 AM" src="https://github.com/aws/jsii-compiler/assets/35242245/af21c4ac-7160-4c44-bdb4-afdf3d249074">

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0