### PR TITLE
fix: outDir tsconfig is incorrectly rejected

### DIFF
--- a/src/tsconfig/rulesets/jsii-configured-options.ts
+++ b/src/tsconfig/rulesets/jsii-configured-options.ts
@@ -4,7 +4,7 @@ import { Match, RuleSet } from '../validator';
 // This is an internal rule set, that may be used by other rule sets.
 // We accept all value for these
 const jsiiConfiguredOptions = new RuleSet();
-jsiiConfiguredOptions.shouldPass('outdir', Match.ANY);
+jsiiConfiguredOptions.shouldPass('outDir', Match.ANY);
 jsiiConfiguredOptions.shouldPass('rootDir', Match.ANY);
 jsiiConfiguredOptions.shouldPass('forceConsistentCasingInFileNames', Match.ANY);
 jsiiConfiguredOptions.shouldPass('declarationMap', Match.ANY);

--- a/test/tsconfig/tsconfig-validator.test.ts
+++ b/test/tsconfig/tsconfig-validator.test.ts
@@ -49,3 +49,23 @@ describe('rule sets', () => {
     );
   });
 });
+
+describe('ruleset: strict', () => {
+  test('can set outDir', () => {
+    const validator = new TypeScriptConfigValidator(TypeScriptConfigValidationRuleSet.STRICT);
+    validator.validate({
+      compilerOptions: {
+        outDir: 'lib',
+
+        // minimal stuff to pass test
+        strict: true,
+        target: 'es2022' as any,
+        lib: ['es2022'],
+        module: 'node16' as any,
+        esModuleInterop: true,
+        skipLibCheck: true,
+        noEmitOnError: true,
+      },
+    });
+  });
+});


### PR DESCRIPTION
When validating a tsconfig, the `outDir` config was incorrectly rejected with the following error message:

```
outDir: Unexpected field, got: outDir
```

This was due to a typo.


Relates to #1201 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0