### PR TITLE
fix: typesVersions not respecting outDir from tsconfig file

### DIFF
--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -13,6 +13,7 @@ import { symbolIdentifier } from './common/symbol-id';
 import { Directives } from './directives';
 import { getReferencedDocParams, parseSymbolDocumentation, TypeSystemHints } from './docs';
 import { Emitter } from './emitter';
+import { normalizeConfigPath } from './helpers';
 import { JsiiDiagnostic } from './jsii-diagnostic';
 import * as literate from './literate';
 import * as bindings from './node-bindings';
@@ -102,7 +103,8 @@ export class Assembler implements Emitter {
 
     // If out-of-source build was configured (tsc's outDir and rootDir), the
     // main file's path needs to be re-rooted from the outDir into the rootDir.
-    const tscOutDir = program.getCompilerOptions().outDir;
+    // outDir might be also be absolute, so we need to normalize it.
+    const tscOutDir = normalizeConfigPath(projectInfo.projectRoot, program.getCompilerOptions().outDir);
     if (tscOutDir != null) {
       mainFile = path.relative(tscOutDir, mainFile);
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -326,3 +326,18 @@ export class TestWorkspace {
 
 // Alias for backwards compatibility
 export type PackageInfo = PackageJson;
+
+/**
+ * TSConfig paths can either be relative to the project or absolute.
+ * This function normalizes paths to be relative to the provided root.
+ * After normalization, code using these paths can be much simpler.
+ *
+ * @param root the project root
+ * @param pathToNormalize the path to normalize, might be empty
+ */
+export function normalizeConfigPath(root: string, pathToNormalize?: string): string | undefined {
+  if (pathToNormalize == null || !path.isAbsolute(pathToNormalize)) {
+    return pathToNormalize;
+  }
+  return path.relative(root, pathToNormalize);
+}

--- a/test/downlevel.test.ts
+++ b/test/downlevel.test.ts
@@ -1,0 +1,215 @@
+import { mkdtempSync, writeFileSync, readFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Compiler } from '../src/compiler';
+import { TYPES_COMPAT } from '../src/downlevel-dts';
+import { PackageJson, ProjectInfo } from '../src/project-info';
+
+describe('Compiler', () => {
+  describe('generated tsconfig', () => {
+    test('will downlevel code', () => {
+      // GIVEN
+      const sourceDir = mkdtempSync(join(tmpdir(), 'jsii-compiler-generated-'));
+      _writeDownlevelableCode(sourceDir);
+
+      // WHEN
+      const compiler = new Compiler({
+        projectInfo: {
+          ..._makeProjectInfo(sourceDir, 'index.d.ts'),
+        },
+      });
+      const result = compiler.emit();
+
+      // THEN code compiles
+      expect(result.diagnostics).toHaveLength(0);
+      expect(result.emitSkipped).toBe(false);
+      // THEN code is downleveled
+      const downleveled = readFileSync(join(sourceDir, '.types-compat/ts3.9/index.d.ts'), 'utf-8');
+      expect(downleveled).toMatchInlineSnapshot(`
+        "declare class MarkerA {
+        }
+        export type { MarkerA };
+        "
+      `);
+      // THEN typeVersions are written
+      const packageJson = readPackageJson(sourceDir);
+      expect(packageJson.typesVersions).toMatchObject({
+        '<=3.9': {
+          '*': ['.types-compat/ts3.9/*', '.types-compat/ts3.9/*/index.d.ts'],
+        },
+      });
+      // THEN
+      const tsconfig = JSON.parse(readFileSync(join(sourceDir, 'tsconfig.json'), 'utf-8'));
+      expect(tsconfig.exclude).toMatchInlineSnapshot(`
+        [
+          "node_modules",
+          ".types-compat",
+        ]
+      `);
+    });
+
+    test('will downlevel code with outdir', () => {
+      // GIVEN
+      const outDir = 'jsii-outdir';
+      const srcDir = 'jsii-srcdir';
+      const projectDir = mkdtempSync(join(tmpdir(), 'jsii-compiler-generated-'));
+      mkdirSync(join(projectDir, srcDir), { recursive: true });
+      _writeDownlevelableCode(projectDir, srcDir);
+
+      // WHEN
+      const compiler = new Compiler({
+        projectInfo: {
+          ..._makeProjectInfo(projectDir, join(outDir, 'index.d.ts')),
+          tsc: {
+            outDir,
+            rootDir: srcDir,
+          },
+        },
+      });
+      const result = compiler.emit();
+
+      // THEN code compiles
+      expect(result.diagnostics).toHaveLength(0);
+      expect(result.emitSkipped).toBe(false);
+      // THEN code is downleveled
+      const downleveled = readFileSync(join(projectDir, outDir, '.types-compat/ts3.9/index.d.ts'), 'utf-8');
+      expect(downleveled).toMatchInlineSnapshot(`
+        "declare class MarkerA {
+        }
+        export type { MarkerA };
+        "
+      `);
+      // THEN typeVersions are written
+      const packageJson = readPackageJson(projectDir);
+      expect(packageJson.typesVersions).toMatchObject({
+        '<=3.9': {
+          'jsii-outdir/*': ['jsii-outdir/.types-compat/ts3.9/*', 'jsii-outdir/.types-compat/ts3.9/*/index.d.ts'],
+        },
+      });
+      // THEN
+      const tsconfig = JSON.parse(readFileSync(join(projectDir, 'tsconfig.json'), 'utf-8'));
+      expect(tsconfig.exclude).toMatchInlineSnapshot(`
+        [
+          "node_modules",
+          "jsii-outdir/.types-compat",
+        ]
+      `);
+    });
+  });
+
+  describe('user-provided tsconfig', () => {
+    test('will downlevel code with outdir', () => {
+      // GIVEN
+      const outDir = 'jsii-outdir';
+      const srcDir = 'jsii-srcdir';
+      const projectDir = mkdtempSync(join(tmpdir(), 'jsii-compiler-user-tsconfig-'));
+      mkdirSync(join(projectDir, srcDir), { recursive: true });
+      const tsconfigPath = 'tsconfig.dev.json';
+      writeFileSync(
+        join(projectDir, tsconfigPath),
+        JSON.stringify(
+          tsconfigForNode18Strict({
+            outDir,
+            rootDir: srcDir,
+          }),
+          null,
+          2,
+        ),
+      );
+      _writeDownlevelableCode(projectDir, srcDir);
+
+      // WHEN
+      const compiler = new Compiler({
+        projectInfo: _makeProjectInfo(projectDir, join(outDir, 'index.d.ts')),
+        typeScriptConfig: tsconfigPath,
+      });
+      const result = compiler.emit();
+
+      // THEN code compiles
+      expect(result.diagnostics).toHaveLength(0);
+      expect(result.emitSkipped).toBe(false);
+      // THEN code is downleveled
+      const downleveled = readFileSync(join(projectDir, outDir, '.types-compat/ts3.9/index.d.ts'), 'utf-8');
+      expect(downleveled).toMatchInlineSnapshot(`
+        "declare class MarkerA {
+        }
+        export type { MarkerA };
+        "
+      `);
+      // THEN typeVersions are written
+      const packageJson = readPackageJson(projectDir);
+      expect(packageJson.typesVersions).toMatchObject({
+        '<=3.9': {
+          'jsii-outdir/*': ['jsii-outdir/.types-compat/ts3.9/*', 'jsii-outdir/.types-compat/ts3.9/*/index.d.ts'],
+        },
+      });
+    });
+  });
+});
+
+function readPackageJson(dir: string): PackageJson {
+  return JSON.parse(readFileSync(join(dir, 'package.json'), 'utf-8'));
+}
+
+function _writeDownlevelableCode(projectDir: string, codeSubDir?: string) {
+  // Files in the project dir
+  writeFileSync(join(projectDir, 'README.md'), '# Test Package');
+  writeFileSync(join(projectDir, 'package.json'), JSON.stringify({}, null, 2));
+
+  // Files in the code dir, e.g. `src`
+  const codeDir = codeSubDir ? join(projectDir, codeSubDir) : projectDir;
+  // See https://www.npmjs.com/package/downlevel-dts#type-modifiers-on-importexport-names-45
+  writeFileSync(join(codeDir, 'index.ts'), 'class MarkerA {} export { type MarkerA }');
+}
+
+function _makeProjectInfo(sourceDir: string, types: string): ProjectInfo {
+  return {
+    projectRoot: sourceDir,
+    description: 'test',
+    homepage: 'https://github.com/aws/jsii-compiler',
+    packageJson: {},
+    types,
+    main: types.replace(/(?:\.d)?\.ts(x?)/, '.js$1'),
+    name: 'jsii', // That's what package.json would tell if we look up...
+    version: '0.0.1',
+    jsiiVersionFormat: 'short',
+    license: 'Apache-2.0',
+    author: { name: 'John Doe', roles: ['author'] },
+    repository: { type: 'git', url: 'https://github.com/aws/jsii.git' },
+    dependencies: {},
+    peerDependencies: {},
+    dependencyClosure: [],
+    bundleDependencies: {},
+    targets: {},
+    excludeTypescript: [],
+    tsc: {
+      // NOTE: these are the default values jsii uses when none are provided in package.json.
+      inlineSourceMap: true,
+      inlineSources: true,
+    },
+  };
+}
+
+/**
+ * An example of a user-provided config, based on the popular tsconfig/bases project & adjusted for the strict rule set
+ * @see https://github.com/tsconfig/bases/blob/main/bases/node18.json
+ */
+function tsconfigForNode18Strict(compilerOptions: any = {}) {
+  return {
+    compilerOptions: {
+      lib: ['es2022'],
+      module: 'node16',
+      target: 'es2022',
+
+      strict: true,
+      esModuleInterop: true,
+      skipLibCheck: true,
+      noEmitOnError: true,
+      moduleResolution: 'node16',
+      declaration: true,
+      ...compilerOptions,
+    },
+    exclude: ['node_modules', TYPES_COMPAT],
+    include: [join('**', '*.ts')],
+  };
+}


### PR DESCRIPTION
Fixes #1234 

Also fixes an issue related the `.type-compat` output path that was discovered when adding tests. When getting `outdir` from the program, this might be either a relative or absolute path. Previously the code assumed it was always relative which is not correct. This led to absolute paths being used for the `.type-compat` dir and in the post processing; ultimately leading to a compilation failure. The fix is to ensure `outdir` & `.type-compat` are normalized to a relative path.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0