### PR TITLE
fix(tsconfig): omitting `declaration` in custom config does not fail tsconfig validation

### DIFF
--- a/src/tsconfig/rulesets/incompatible-options.ts
+++ b/src/tsconfig/rulesets/incompatible-options.ts
@@ -6,5 +6,6 @@ const incompatibleOptions = new RuleSet();
 incompatibleOptions.shouldFail('noEmit', Match.TRUE);
 incompatibleOptions.shouldFail('noLib', Match.TRUE);
 incompatibleOptions.shouldFail('declaration', Match.FALSE);
+incompatibleOptions.shouldFail('emitDeclarationOnly', Match.TRUE);
 
 export default incompatibleOptions;

--- a/src/tsconfig/rulesets/strict.public.ts
+++ b/src/tsconfig/rulesets/strict.public.ts
@@ -30,6 +30,7 @@ strict.shouldPass('esModuleInterop', Match.TRUE);
 strict.shouldPass('skipLibCheck', Match.TRUE);
 strict.shouldPass('stripInternal', Match.optional(Match.FALSE));
 strict.shouldPass('noEmitOnError', Match.TRUE);
+strict.shouldPass('declaration', Match.TRUE);
 
 // Deprecated ts options that should not be used with jsii
 strict.import(deprecatedOptions);

--- a/test/compiler.test.ts
+++ b/test/compiler.test.ts
@@ -474,6 +474,7 @@ function tsconfigForNode18Strict() {
       skipLibCheck: true,
       noEmitOnError: true,
       moduleResolution: 'node16',
+      declaration: true,
     },
     exclude: ['node_modules', TYPES_COMPAT],
     include: [join('**', '*.ts')],

--- a/test/tsconfig/tsconfig-validator.test.ts
+++ b/test/tsconfig/tsconfig-validator.test.ts
@@ -65,6 +65,7 @@ describe('ruleset: strict', () => {
         esModuleInterop: true,
         skipLibCheck: true,
         noEmitOnError: true,
+        declaration: true,
       },
     });
   });


### PR DESCRIPTION
jsii will fail if no declarations are emitted.

This setting was not previously enforced, because tsc defaults to emitting declarations in some situations. However since its not the default for all allowed configurations, we should enforce it.

Also adds `emitDeclarationOnly: true` to the list of incompatible settings. Without compiled js files, jsii programs don't work either.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0