### PR TITLE
feat(tsconfig): mark verbatimModuleSyntax, isolatedModules & isolatedDeclarations options as configurable

### DIFF
--- a/src/tsconfig/rulesets/configurable-options.ts
+++ b/src/tsconfig/rulesets/configurable-options.ts
@@ -18,5 +18,8 @@ configurableOptions.shouldPass('noUnusedParameters', Match.ANY);
 configurableOptions.shouldPass('resolveJsonModule', Match.ANY);
 configurableOptions.shouldPass('experimentalDecorators', Match.ANY);
 configurableOptions.shouldPass('noFallthroughCasesInSwitch', Match.ANY);
+configurableOptions.shouldPass('verbatimModuleSyntax', Match.ANY);
+configurableOptions.shouldPass('isolatedModules', Match.ANY);
+configurableOptions.shouldPass('isolatedDeclarations', Match.ANY);
 
 export default configurableOptions;

--- a/test/tsconfig/tsconfig-validator.test.ts
+++ b/test/tsconfig/tsconfig-validator.test.ts
@@ -69,24 +69,4 @@ describe('ruleset: strict', () => {
       },
     });
   });
-
-  test('can use isolated* configs', () => {
-    const validator = new TypeScriptConfigValidator(TypeScriptConfigValidationRuleSet.STRICT);
-    validator.validate({
-      compilerOptions: {
-        isolatedDeclarations: true,
-        isolatedModules: true,
-
-        // minimal stuff to pass test
-        strict: true,
-        target: 'es2022' as any,
-        lib: ['es2022'],
-        module: 'node16' as any,
-        esModuleInterop: true,
-        skipLibCheck: true,
-        noEmitOnError: true,
-        declaration: true,
-      },
-    });
-  });
 });

--- a/test/tsconfig/tsconfig-validator.test.ts
+++ b/test/tsconfig/tsconfig-validator.test.ts
@@ -69,4 +69,24 @@ describe('ruleset: strict', () => {
       },
     });
   });
+
+  test('can use isolated* configs', () => {
+    const validator = new TypeScriptConfigValidator(TypeScriptConfigValidationRuleSet.STRICT);
+    validator.validate({
+      compilerOptions: {
+        isolatedDeclarations: true,
+        isolatedModules: true,
+
+        // minimal stuff to pass test
+        strict: true,
+        target: 'es2022' as any,
+        lib: ['es2022'],
+        module: 'node16' as any,
+        esModuleInterop: true,
+        skipLibCheck: true,
+        noEmitOnError: true,
+        declaration: true,
+      },
+    });
+  });
 });


### PR DESCRIPTION
The `isolatedModules` & `isolatedDeclarations` options increase the strictness of the TypeScript compiler.

The `verbatimModuleSyntax` option is a modern replacement for a set of older options that influence if unused imports a
persevered in the JS output. As such it is irrelevant to the jsii type system and at the discretion of the user.

No testing required, as these are covered by the existing proptest.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0