### PR TITLE
fix: omitting optional property fails C# compilation

### DIFF
--- a/src/jsii-diagnostic.ts
+++ b/src/jsii-diagnostic.ts
@@ -631,7 +631,7 @@ export class JsiiDiagnostic implements ts.Diagnostic {
   public static readonly JSII_5021_ABSTRACT_CLASS_MISSING_PROP_IMPL = Code.error({
     code: 5021,
     formatter: (intf: spec.InterfaceType, cls: spec.ClassType, prop: string) =>
-      `A declaration of "${intf.name}.${prop}" is missing on class "${cls.name}". Declare it as "public abstract" if the omission was on purpose.`,
+      `A declaration of "${intf.name}.${prop}" is missing on class "${cls.name}". Declare the property as "public abstract" if you want to defer it to subclasses.`,
     name: 'language-compatibility/abstract-class-missing-prop-impl',
   });
 

--- a/src/jsii-diagnostic.ts
+++ b/src/jsii-diagnostic.ts
@@ -628,6 +628,13 @@ export class JsiiDiagnostic implements ts.Diagnostic {
     name: 'language-compatibility/static-member-name-conflicts-with-nested-type',
   });
 
+  public static readonly JSII_5021_ABSTRACT_CLASS_MISSING_PROP_IMPL = Code.error({
+    code: 5021,
+    formatter: (intf: spec.InterfaceType, cls: spec.ClassType, prop: string) =>
+      `A declaration of "${intf.name}.${prop}" is missing on class "${cls.name}". Declare it as "public abstract" if the omission was on purpose.`,
+    name: 'language-compatibility/abstract-class-missing-prop-impl',
+  });
+
   //////////////////////////////////////////////////////////////////////////////
   // 6000 => 6999 -- RESERVED
 

--- a/test/__snapshots__/negatives.test.ts.snap
+++ b/test/__snapshots__/negatives.test.ts.snap
@@ -574,6 +574,21 @@ error JSII5001: Methods and properties cannot have names like "setXxx": those co
 
 `;
 
+exports[`missing-abstract 1`] = `
+neg.missing-abstract.ts:5:1 - error JSII5021: A declaration of "ISomeInterface.xyz" is missing on class "SomeClass". Declare it as "public abstract" if the omission was on purpose.
+
+5 export abstract class SomeClass implements ISomeInterface {
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+6 }
+  ~
+
+  neg.missing-abstract.ts:2:3
+    2   readonly xyz?: string;
+        ~~~~~~~~~~~~~~~~~~~~~~
+    The implemented delcaration is here.
+
+`;
+
 exports[`mix-datatype-and-arg-name 1`] = `
 neg.mix-datatype-and-arg-name.ts:10:3 - error JSII5017: Parameter name "dontWorry" is also the name of a property in a struct parameter. Rename the positional parameter.
 

--- a/test/__snapshots__/negatives.test.ts.snap
+++ b/test/__snapshots__/negatives.test.ts.snap
@@ -575,7 +575,7 @@ error JSII5001: Methods and properties cannot have names like "setXxx": those co
 `;
 
 exports[`missing-abstract 1`] = `
-neg.missing-abstract.ts:5:1 - error JSII5021: A declaration of "ISomeInterface.xyz" is missing on class "SomeClass". Declare it as "public abstract" if the omission was on purpose.
+neg.missing-abstract.ts:5:1 - error JSII5021: A declaration of "ISomeInterface.xyz" is missing on class "SomeClass". Declare the property as "public abstract" if you want to defer it to subclasses.
 
 5 export abstract class SomeClass implements ISomeInterface {
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/test/__snapshots__/negatives.test.ts.snap
+++ b/test/__snapshots__/negatives.test.ts.snap
@@ -106,7 +106,7 @@ neg.downgrade-to-readonly.ts:8:24 - error JSII5010: "jsii.Implementation#propert
   neg.downgrade-to-readonly.ts:4:5
     4     property: string;
           ~~~~~~~~
-    The implemented delcaration is here.
+    The implemented declaration is here.
 
 `;
 
@@ -296,7 +296,7 @@ neg.implementation-changes-types.4.ts:9:21 - error JSII5004: "jsii.SomethingImpl
   neg.implementation-changes-types.4.ts:5:14
     5   something: Superclass;
                    ~~~~~~~~~~
-    The implemented delcaration is here.
+    The implemented declaration is here.
 
 `;
 
@@ -309,7 +309,7 @@ neg.implementation-changes-types.5.ts:14:21 - error JSII5004: "jsii.ISomethingEl
   neg.implementation-changes-types.5.ts:5:14
     5   something: Superclass;
                    ~~~~~~~~~~
-    The implemented delcaration is here.
+    The implemented declaration is here.
 
 `;
 
@@ -337,7 +337,7 @@ neg.implementing-property-changes-optionality.ts:7:20 - error JSII5009: "jsii.Im
   neg.implementing-property-changes-optionality.ts:3:11
     3   property?: string;
                 ~
-    The implemented delcaration is here.
+    The implemented declaration is here.
 
 `;
 
@@ -350,7 +350,7 @@ neg.implementing-property-changes-optionality.1.ts:7:20 - error JSII5009: "jsii.
   neg.implementing-property-changes-optionality.1.ts:3:27
     3   public abstract property?: string;
                                 ~
-    The implemented delcaration is here.
+    The implemented declaration is here.
 
 `;
 
@@ -363,7 +363,7 @@ neg.implementing-property-changes-optionality.2.ts:7:20 - error JSII5009: "jsii.
   neg.implementing-property-changes-optionality.2.ts:3:18
     3   public property?: string = undefined;
                        ~
-    The implemented delcaration is here.
+    The implemented declaration is here.
 
 `;
 
@@ -421,7 +421,7 @@ neg.inheritance-changes-types.4.ts:9:21 - error JSII5004: "jsii.SomethingSpecifi
   neg.inheritance-changes-types.4.ts:5:10
     5   public something = new Superclass();
                ~~~~~~~~~
-    The implemented delcaration is here.
+    The implemented declaration is here.
 
 `;
 
@@ -434,7 +434,7 @@ neg.inheritance-changes-types.5.ts:14:21 - error JSII5004: "jsii.SomethingElse#s
   neg.inheritance-changes-types.5.ts:5:21
     5   public something: Superclass = new Superclass();
                           ~~~~~~~~~~
-    The implemented delcaration is here.
+    The implemented declaration is here.
 
 `;
 
@@ -447,7 +447,7 @@ neg.inheritance-changes-types.from-base.ts:6:30 - error JSII5009: "jsii.HasRequi
   neg.inheritance-changes-types.from-base.ts:2:28
     2   readonly optionalProperty?: number;
                                  ~
-    The implemented delcaration is here.
+    The implemented declaration is here.
 
 `;
 
@@ -585,7 +585,7 @@ neg.missing-abstract.ts:5:1 - error JSII5021: A declaration of "ISomeInterface.x
   neg.missing-abstract.ts:2:3
     2   readonly xyz?: string;
         ~~~~~~~~~~~~~~~~~~~~~~
-    The implemented delcaration is here.
+    The implemented declaration is here.
 
 `;
 
@@ -682,7 +682,7 @@ neg.override-changes-visibility.ts:14:3 - error JSII5002: "jsii.ChildClass#prope
   neg.override-changes-visibility.ts:5:3
     5   protected readonly property?: string;
         ~~~~~~~~~
-    The implemented delcaration is here.
+    The implemented declaration is here.
 error JSII5002: "jsii.ChildClass#method" changes visibility to public when overriding jsii.BaseClass. Change it to protected
 
 `;

--- a/test/negatives/neg.missing-abstract.ts
+++ b/test/negatives/neg.missing-abstract.ts
@@ -1,0 +1,6 @@
+export interface ISomeInterface {
+  readonly xyz?: string;
+}
+
+export abstract class SomeClass implements ISomeInterface {
+}


### PR DESCRIPTION
The following is a minimal reproducing example:

```ts
export interface ISomeInterface {
  readonly xyz?: string;
}

export abstract class SomeClass implements ISomeInterface {
}
```

This breaks code generation for C#, as the `SomeClass._Proxy` class we generate will try to generate an `override` for the `Xyz` property, which is missing from the `SomeClass` class itself.

This issue is exhibited by a difference in logic between how we iterate the members of a class when we generate the class itself vs when we generate its proxy.

However, after looking at the code I'm not convinced it's correct either way (nor for Java), so to be safe we picked the solution where we force the user to declare the property on the class.

The correct declaration would be:

```ts
export abstract class SomeClass implements ISomeInterface {
  public abstract readonly xyz?: string;
}
```

Related: https://github.com/aws/aws-cdk/pull/31946/files

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0