### PR TITLE
fix: disable experimental decorator flag

### DIFF
--- a/src/tsconfig/compiler-options.ts
+++ b/src/tsconfig/compiler-options.ts
@@ -4,7 +4,6 @@ import * as Case from '../case';
 export const BASE_COMPILER_OPTIONS: ts.CompilerOptions = {
   alwaysStrict: true,
   declaration: true,
-  experimentalDecorators: true,
   incremental: true,
   lib: ['lib.es2020.d.ts'],
   module: ts.ModuleKind.CommonJS,

--- a/test/compiler.test.ts
+++ b/test/compiler.test.ts
@@ -484,7 +484,6 @@ function expectedTypeScriptConfig() {
       alwaysStrict: true,
       composite: false,
       declaration: true,
-      experimentalDecorators: true,
       incremental: true,
       inlineSourceMap: true,
       inlineSources: true,


### PR DESCRIPTION
The `experimentalDecorators` flag is legacy from TypeScript 3.9.

Since then, decorators have gone through a large change and their new syntax, which is enabled by default in TypeScript 5+, looks very different.

Keeping this old flag enabled locks users into old decorator typings which are deprecated, plus because of the way our defaults are applied these flags are not overridable.

Instead, don't set `experimentalDecorators` at all, and have users opt in to legacy syntax if they must.

This is technically breaking, but I'm pretty sure this will affect such a negligible fraction of users that I think it's worth it.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0