### PR TITLE
feat: Add full warnings list, dont ouput warning if disabled

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -15,6 +15,7 @@ import { BASE_COMPILER_OPTIONS, convertForJson } from './tsconfig/compiler-optio
 import { TypeScriptConfigValidator } from './tsconfig/tsconfig-validator';
 import { ValidationError } from './tsconfig/validator';
 import * as utils from './utils';
+import { enabledWarnings } from './warnings';
 
 const LOG = log4js.getLogger('jsii/compiler');
 export const DIAGNOSTICS = 'diagnostics';
@@ -182,7 +183,10 @@ export class Compiler implements Emitter {
 
       // emit a warning if validation is disabled
       const rules = this.options.validateTypeScriptConfig ?? TypeScriptConfigValidationRuleSet.NONE;
-      if (rules === TypeScriptConfigValidationRuleSet.NONE) {
+      if (
+        rules === TypeScriptConfigValidationRuleSet.NONE &&
+        enabledWarnings['typescript-config/disabled-tsconfig-validation']
+      ) {
         utils.logDiagnostic(
           JsiiDiagnostic.JSII_4009_DISABLED_TSCONFIG_VALIDATION.create(undefined, this.configPath),
           this.projectRoot,

--- a/src/directives.ts
+++ b/src/directives.ts
@@ -1,5 +1,6 @@
 import * as ts from 'typescript';
 import { JsiiDiagnostic } from './jsii-diagnostic';
+import { enabledWarnings } from './warnings';
 
 /**
  * TSDoc-style directives that can be attached to a symbol.
@@ -40,7 +41,7 @@ export class Directives {
           break;
         case 'jsii':
           const comments = getComments(tag);
-          if (comments.length === 0) {
+          if (comments.length === 0 && enabledWarnings['jsii-directive/missing-argument']) {
             onDiagnostic(JsiiDiagnostic.JSII_2000_MISSING_DIRECTIVE_ARGUMENT.create(tag));
             continue;
           }
@@ -50,7 +51,9 @@ export class Directives {
                 this.ignore ??= jsdocNode;
                 break;
               default:
-                onDiagnostic(JsiiDiagnostic.JSII_2999_UNKNOWN_DIRECTIVE.create(jsdocNode, text));
+                if (enabledWarnings['jsii-directive/unknown']) {
+                  onDiagnostic(JsiiDiagnostic.JSII_2999_UNKNOWN_DIRECTIVE.create(jsdocNode, text));
+                }
                 break;
             }
           }

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,9 +13,7 @@ import { emitSupportPolicyInformation } from './support';
 import { TypeScriptConfigValidationRuleSet } from './tsconfig';
 import * as utils from './utils';
 import { VERSION } from './version';
-import { enabledWarnings } from './warnings';
-
-const warningTypes = Object.keys(enabledWarnings);
+import { enabledWarnings, silenceWarnings } from './warnings';
 
 function choiceWithDesc(
   choices: { [choice: string]: string },
@@ -91,7 +89,7 @@ const ruleSets: {
             group: OPTION_GROUP.JSII,
             type: 'array',
             default: [],
-            desc: `List of warnings to silence (warnings: ${warningTypes.join(',')})`,
+            desc: `List of warnings to silence (warnings: ${Object.keys(enabledWarnings).join(',')})`,
           })
           .option('strip-deprecated', {
             group: OPTION_GROUP.JSII,
@@ -149,16 +147,7 @@ const ruleSets: {
 
           const { projectInfo, diagnostics: projectInfoDiagnostics } = loadProjectInfo(projectRoot);
 
-          // disable all silenced warnings
-          for (const key of argv['silence-warnings']) {
-            if (!(key in enabledWarnings)) {
-              throw new utils.JsiiError(
-                `Unknown warning type ${key as any}. Must be one of: ${warningTypes.join(', ')}`,
-              );
-            }
-
-            enabledWarnings[key] = false;
-          }
+          silenceWarnings(argv['silence-warnings'] as string[]);
 
           configureCategories(projectInfo.diagnostics ?? {});
 

--- a/src/project-info.ts
+++ b/src/project-info.ts
@@ -10,6 +10,7 @@ import { findDependencyDirectory } from './common/find-utils';
 import { JsiiDiagnostic } from './jsii-diagnostic';
 import { TypeScriptConfigValidationRuleSet } from './tsconfig';
 import { JsiiError, parsePerson, parseRepository } from './utils';
+import { enabledWarnings } from './warnings';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
 const spdx: Set<string> = require('spdx-license-list/simple');
@@ -178,16 +179,18 @@ export function loadProjectInfo(projectRoot: string): ProjectInfoResult {
     const range = new semver.Range(_resolveVersion(rng as string, projectRoot).version);
     const minVersion = semver.minVersion(range)?.raw;
 
-    if (!(name in devDependencies) || devDependencies[name] !== `${minVersion}`) {
-      diagnostics.push(
-        JsiiDiagnostic.JSII_0006_MISSING_DEV_DEPENDENCY.createDetached(
-          name,
-          `${rng as any}`,
-          `${minVersion}`,
-          `${devDependencies[name]}`,
-        ),
-      );
-      continue;
+    if (enabledWarnings['metadata/missing-dev-dependency']) {
+      if (!(name in devDependencies) || devDependencies[name] !== `${minVersion}`) {
+        diagnostics.push(
+          JsiiDiagnostic.JSII_0006_MISSING_DEV_DEPENDENCY.createDetached(
+            name,
+            `${rng as any}`,
+            `${minVersion}`,
+            `${devDependencies[name]}`,
+          ),
+        );
+        continue;
+      }
     }
   }
 

--- a/src/warnings.ts
+++ b/src/warnings.ts
@@ -1,7 +1,39 @@
+import { JsiiError } from './utils';
+
 /**
  * Indicates which warnings are currently enabled. By default all warnings are
  * enabled, and can be silenced through the --silence-warning option.
  */
-export const enabledWarnings: { [name: string]: boolean } = {
-  'reserved-word': true,
+export const enabledWarnings = {
+  'metadata/missing-readme': true,
+  'metadata/missing-peer-dependency': true,
+  'metadata/missing-dev-dependency': true,
+  'jsii-directive/missing-argument': true,
+  'jsii-directive/struct-on-non-interface': true,
+  'jsii-directive/unknown': true,
+  'typescript-config/disabled-tsconfig-validation': true,
+  'language-compatibility/reserved-word': true,
+  'language-compatibility/member-name-conflicts-with-type-name': true,
+  'documentation/non-existent-parameter': true,
+};
+
+export const silenceWarnings = (warnings: string[]): void => {
+  const legacyWarningKeyReplacement: { [key: string]: string } = {
+    'reserved-word': 'language-compatibility/reserved-word',
+  };
+  const legacyWarningKeys = Object.keys(legacyWarningKeyReplacement);
+
+  for (const key of warnings) {
+    if (!(key in enabledWarnings) && !legacyWarningKeys.includes(key)) {
+      throw new JsiiError(
+        `Unknown warning type ${key as any}. Must be one of: ${Object.keys(enabledWarnings).join(', ')}`,
+      );
+    }
+
+    if (legacyWarningKeys.includes(key)) {
+      enabledWarnings[legacyWarningKeyReplacement[key] as keyof typeof enabledWarnings] = false;
+    } else {
+      enabledWarnings[key as keyof typeof enabledWarnings] = false;
+    }
+  }
 };

--- a/test/warnings.test.ts
+++ b/test/warnings.test.ts
@@ -1,0 +1,36 @@
+import { DiagnosticCategory } from 'typescript';
+import { Code, JsiiDiagnostic } from '../src/jsii-diagnostic';
+import { JsiiError } from '../src/utils';
+import { enabledWarnings, silenceWarnings } from '../src/warnings';
+
+describe('enabledWarnings', () => {
+  test('contains all available Jsii warnings', () => {
+    const definedWarnings = Object.keys(JsiiDiagnostic).reduce((warnings, warningKey) => {
+      const code = JsiiDiagnostic[warningKey as keyof typeof JsiiDiagnostic];
+      if (code instanceof Code && code.category === DiagnosticCategory.Warning) {
+        warnings[code.name] = true;
+      }
+      return warnings;
+    }, {} as { [name: string]: boolean });
+
+    expect(enabledWarnings).toStrictEqual(definedWarnings);
+  });
+});
+
+describe('silenceWarnings', () => {
+  test('sets enabledWarnings key to false', () => {
+    expect(enabledWarnings['metadata/missing-readme']).toBe(true);
+    silenceWarnings(['metadata/missing-readme']);
+    expect(enabledWarnings['metadata/missing-readme']).toBe(false);
+  });
+
+  test('translates legacy key to current Code.name', () => {
+    expect(enabledWarnings['language-compatibility/reserved-word']).toBe(true);
+    silenceWarnings(['reserved-word']);
+    expect(enabledWarnings['language-compatibility/reserved-word']).toBe(false);
+  });
+
+  test('throws when key is not valid', () => {
+    expect(() => silenceWarnings(['invalid-warning'])).toThrow(JsiiError);
+  });
+});


### PR DESCRIPTION
Added full warning list w/ test for future warnings. Checked warning list before pushing diagnostic item.

Note: `jsii-directive/struct-on-non-interface` had nothing using it from what I could tell.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0