### PR TITLE
chore: report date and not time for end of support warning

### DIFF
--- a/src/support.ts
+++ b/src/support.ts
@@ -85,7 +85,9 @@ export async function emitSupportPolicyInformation() {
     // End-of-Support within 30 days!
     veryVisibleMessage(
       chalk.bgYellow.black,
-      `The ${RELEASE_LINE} release line of jsii will reach End-of-Support soon, on ${endOfSupportDate.toISOString().split('T')[0]}.`,
+      `The ${RELEASE_LINE} release line of jsii will reach End-of-Support soon, on ${
+        endOfSupportDate.toISOString().split('T')[0]
+      }.`,
       `We strongly recommend you upgrade to the current release line (${data.current}) at your earliest convenience.`,
       ...alternatives,
     );

--- a/src/support.ts
+++ b/src/support.ts
@@ -70,7 +70,7 @@ export async function emitSupportPolicyInformation() {
       if (acc.length === 0) {
         acc.push('', 'Other actively supported release lines include:');
       }
-      acc.push(`- ${release} (planned End-of-Support date: ${date.toISOString()})`);
+      acc.push(`- ${release} (planned End-of-Support date: ${date.toLocaleDateString()})`);
       return acc;
     }, new Array<string>());
   if (endOfSupportDate <= now) {
@@ -85,7 +85,7 @@ export async function emitSupportPolicyInformation() {
     // End-of-Support within 30 days!
     veryVisibleMessage(
       chalk.bgYellow.black,
-      `The ${RELEASE_LINE} release line of jsii will reach End-of-Support soon, on ${endOfSupportDate.toISOString()}.`,
+      `The ${RELEASE_LINE} release line of jsii will reach End-of-Support soon, on ${endOfSupportDate.toLocaleDateString()}.`,
       `We strongly recommend you upgrade to the current release line (${data.current}) at your earliest convenience.`,
       ...alternatives,
     );

--- a/src/support.ts
+++ b/src/support.ts
@@ -70,7 +70,7 @@ export async function emitSupportPolicyInformation() {
       if (acc.length === 0) {
         acc.push('', 'Other actively supported release lines include:');
       }
-      acc.push(`- ${release} (planned End-of-Support date: ${date.toLocaleDateString()})`);
+      acc.push(`- ${release} (planned End-of-Support date: ${date.toISOString().split('T')[0]})`);
       return acc;
     }, new Array<string>());
   if (endOfSupportDate <= now) {
@@ -85,7 +85,7 @@ export async function emitSupportPolicyInformation() {
     // End-of-Support within 30 days!
     veryVisibleMessage(
       chalk.bgYellow.black,
-      `The ${RELEASE_LINE} release line of jsii will reach End-of-Support soon, on ${endOfSupportDate.toLocaleDateString()}.`,
+      `The ${RELEASE_LINE} release line of jsii will reach End-of-Support soon, on ${endOfSupportDate.toISOString().split('T')[0]}.`,
       `We strongly recommend you upgrade to the current release line (${data.current}) at your earliest convenience.`,
       ...alternatives,
     );


### PR DESCRIPTION
returns `"2025-04-03" ` instead of `"2025-04-03T22:04:47.424Z"`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0