### PR TITLE
fix: clarify remediations of JSII9002

### DIFF
--- a/src/jsii-diagnostic.ts
+++ b/src/jsii-diagnostic.ts
@@ -743,7 +743,7 @@ export class JsiiDiagnostic implements ts.Diagnostic {
   public static readonly JSII_9002_UNRESOLVEABLE_TYPE = Code.error({
     code: 9002,
     formatter: (reference: string) =>
-      `Unable to resolve type "${reference}". It may be @internal or not exported from the module's entry point (as configured in "package.json" as "main").`,
+      `Type "${reference}" is part of the public API but not exported (@internal or not exported from the package.json "main" file). Either export it or add @internal explicitly if you want this to be a hidden base class.`,
     name: 'miscellaneous/unresolveable-type',
   });
 


### PR DESCRIPTION
Rephrase the error message of JSII9002, in order to addres #2082 a bit. We're not fixing the underlying issue, but we make it easier to find the workaround.

When using a purposely hidden interface as a shared base interface between multiple files, this only works if you add `@internal` to the documentation. The error message doesn't make that clear and in fact steers you away from the right solution and tells you to export the thing you didn't want exported.

Make the message bit more pithy and add the alternative out:

Old message:

```
Unable to resolve type "lib.Type". It may be @internal or not exported from the module's entry point (as configured in "package.json" as "main").
```

New message:

```
Type "lib.Type" is part of the public API but not exported (@internal or not exported from the package.json "main" file). Either export it or add @internal explicitly if you want this to be a hidden base class.
```



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0