### PR TITLE
chore: add guidance for adding new jsii features

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,6 @@ documentation, we greatly value feedback and contributions from our community.
 Please read through this document before submitting any issues or pull requests to ensure we have all the necessary
 information to effectively respond to your bug report or contribution.
 
-
 ## Reporting Bugs/Feature Requests
 
 We welcome you to use the GitHub issue tracker to report bugs or suggest features.
@@ -19,8 +18,8 @@ reported the issue. Please try to include as much information as you can. Detail
 * Any modifications you've made relevant to the bug
 * Anything unusual about your environment or deployment
 
-
 ## Contributing via Pull Requests
+
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
 1. You are working against the latest source on the *main* branch.
@@ -39,20 +38,38 @@ To send us a pull request, please:
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 
-
 ## Finding contributions to work on
+
 Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.
 
+## Adding a new feature to jsii-compiler
+
+Jsii assemblies allow declaring support for `features`.
+We use them to introduce support for new syntax that wasn't previously allowed.
+Adding a new feature requires a number of changes to multiple repositories.
+Follow this list as guidance.
+
+1. Declare the new feature in `@jsii/spec` and support it in all tooling in [aws/jsii](https://github.com/aws/jsii).\
+  This needs to be released before continuing with further steps.
+2. Support the new feature in other related tooling.\
+  While not strictly required, it's strongly recommended to support all tools before adding the feature to the jsii-compiler.
+   * [jsii-rosetta](https://github.com/aws/jsii-rosetta) ([example PR](https://github.com/aws/jsii-rosetta/pull/3322))
+   * [jsii-docgen](https://github.com/cdklabs/jsii-docgen) ([example PR](https://github.com/cdklabs/jsii-docgen/pull/1847))
+   * [cdklabs/cdk-generate-synthetic-examples](https://github.com/cdklabs/cdk-generate-synthetic-examples) ([example PR](https://github.com/cdklabs/cdk-generate-synthetic-examples/pull/942))
+   * [Construct Hub](https://github.com/cdklabs/construct-hub) ([example PR](https://github.com/cdklabs/construct-hub/pull/1788))
+   * Official AWS CDK docs website
+3. Add support of the new feature to the compiler in this repository ([example PR](https://github.com/aws/jsii-compiler/pull/2325))
+4. Update jsii docs website in [aws/jsii](https://github.com/aws/jsii) and add end-to-end test cases using the new compiler ([example PR](https://github.com/aws/jsii/pull/4942))
 
 ## Code of Conduct
+
 This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
 For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
-opensource-codeofconduct@amazon.com with any additional questions or comments.
-
+<opensource-codeofconduct@amazon.com> with any additional questions or comments.
 
 ## Security issue notifications
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
 
+If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
 
 ## Licensing
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,10 +1,10 @@
-## Maintenance & Support Policy
+# Maintenance & Support Policy
 
 This document describes the Maintenance & Support Policy applicable to releases
 of the `jsii` compiler ([`npm:jsii`](https://npmjs.com/packages/jsii)) with
 versions `5.0.x` and newer.
 
-### Versioning Scheme
+## Versioning Scheme
 
 In-scope `jsii` release lines use the same `major.minor` version as the
 TypeScript compiler ([`npm:typescript`](https://npmjs.com/packages/typescript))
@@ -12,7 +12,7 @@ they are built with. This means that `jsii@5.0.x` is built on top of
 `typescript@5.0.x`.
 
 Since the `typescript` package does not follow [Semantic Versioning][semver],
-the `jsii` package does not eiher. The `typescript` compiler guarantees no
+the `jsii` package does not either. The `typescript` compiler guarantees no
 breaking change is introduced within a given `major.minor` release line, and
 `jsii` upholds the same guarantee. As a consequence, users are advised to use
 `~` ranges (also referred to as minor-pinned ranges) when declaring dependencies
@@ -24,7 +24,7 @@ is issued).
 
 [semver]: https://semver.org
 
-### Release Lines Lifecycle Stages
+## Release Lines Lifecycle Stages
 
 This Maintenance & Support Policy assigns one of the following lifecycle stages
 to each in-scope `jsii` release line in existence:
@@ -33,7 +33,7 @@ to each in-scope `jsii` release line in existence:
    the release under active development, receiving new features, bug fixes and
    security updates.
 
-1. **Maintenace**: Release lines in **Maintenance** stage are no longer
+1. **Maintenance**: Release lines in **Maintenance** stage are no longer
    considered in active development, and no new features will be added to these.
    They however continue to receive bug fixes and security updates. Users can
    continue to use release lines in **Maintenance** stage indefinitely, but we
@@ -47,7 +47,7 @@ to each in-scope `jsii` release line in existence:
    changes in newer releases at any time. Users are advised to migrate away from
    **End-of-Support** release lines at the earliest convenience.
 
-### Stage Transitions
+## Stage Transitions
 
 ```mermaid
 ---
@@ -66,7 +66,7 @@ stateDiagram-v2
 
 Whenever a new release line is started (typically with a new `x.y.0` release,
 excluding pre-releases), it becomes **Current** and the release line it replaced
-immediately enters the **Maintenace** stage.
+immediately enters the **Maintenance** stage.
 
 Releases stay in the **Maintenance** stage for a minimum of 6 months before they
 reach **End-of-Support**.
@@ -74,7 +74,7 @@ reach **End-of-Support**.
 Once a release line has reached **End-of-Support**, it remains in this stage
 indefinitely.
 
-### Timelines & Communication
+## Timelines & Communication
 
 The `typescript` compiler maintainers start a new release line on a quarterly
 basis, and users should expect the `jsii` compiler maintainers to do the same.
@@ -99,7 +99,7 @@ manifest document.
 The current status of `jsii` compiler release lines is also documented on the
 [repository's `README.md` document][readme].
 
-### Modification
+## Modification
 
 The maintainers of the jsii project reserve the right to modify this Maintenance
 and Support Policy as necessary. Updates will be proposed by way of a pull
@@ -108,13 +108,13 @@ timeline of release lines will be broadly announced to the community via
 established communication channels (such as the `cdk.dev` Slack), and will
 remain open for the community to comment on for a minimum of 15 days.
 
-Community members are welcome to propose changes to the support and maintenace
+Community members are welcome to propose changes to the support and maintenance
 policy through the same process.
 
-### Derogation
+## Derogation
 
 Under _exceptional_ circumstances, the project maintainers may elect to derogate
-from this Support & Maintenance Policy. In cases where the decisision to
+from this Support & Maintenance Policy. In cases where the decision to
 derogate extends supplemental maintenance & support coverage for a release line,
 the increased coverage will be documented in the
 [repository's `README.md` document][readme].


### PR DESCRIPTION
Adds comprehensive guidance for contributors working on new jsii features that span multiple repositories.

The new section explains the complete workflow from @jsii/spec changes through final documentation, includes links to example PRs for each step, and covers the cross-repository dependencies and recommended order of implementation.

This guidance helps contributors understand the full scope of work required when adding new jsii features and ensures proper coordination across the jsii ecosystem.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0