### PR TITLE
chore: remove noise from test output

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -46,6 +46,7 @@ const project = new typescript.TypeScriptProject({
       skipLibCheck: true,
       moduleResolution: javascript.TypeScriptModuleResolution.NODE16,
       module: 'node16',
+      isolatedModules: true,
 
       sourceMap: true,
       inlineSourceMap: false,

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -28,6 +28,7 @@
     "noImplicitOverride": true,
     "skipLibCheck": true,
     "moduleResolution": "node16",
+    "isolatedModules": true,
     "sourceMap": true
   },
   "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,7 @@
     "noImplicitOverride": true,
     "skipLibCheck": true,
     "moduleResolution": "node16",
+    "isolatedModules": true,
     "sourceMap": true,
     "composite": true,
     "declarationMap": true


### PR DESCRIPTION
- Adds `isolatedModules: true` to silence a ts-jest warning about incompatible tsc settings
- Updates `class-covariant-overrides.test.ts` to use helpers so that A/ we can assert on expected errors and B/ errors are not printed to console during test run


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0