### PR TITLE
fix: transitive deprecation warnings are broken

### DIFF
--- a/fixtures/@scope/jsii-calc-base/lib/index.ts
+++ b/fixtures/@scope/jsii-calc-base/lib/index.ts
@@ -20,7 +20,7 @@ export abstract class Base {
 }
 
 export interface TypeToContainVeryBaseProps {
-  readonly veryBaseProps: VeryBaseProps;
+  readonly veryBaseProps: VeryBaseProps[];
 }
 
 export interface BaseProps extends VeryBaseProps {

--- a/src/transforms/deprecation-warnings.ts
+++ b/src/transforms/deprecation-warnings.ts
@@ -128,10 +128,6 @@ export class DeprecationWarningsInjector {
       return this.shouldRenderValidatorCache[type.fqn];
     }
 
-    if (type.fqn === '@scope/jsii-calc-base.TypeToContainVeryBaseProps') {
-      debugger;
-    }
-
     if (this.validatorCacheSeenSet.has(type.fqn)) {
       // To be safe we need to say this is true.
       return true;
@@ -757,7 +753,7 @@ function importedFunctionName(typeName: string, assembly: Assembly, projectInfo:
   if (type) {
     return moduleName !== assembly.name
       ? `require("${moduleName}/${WARNINGSCODE_FILE_NAME}").${fnName(type.fqn)}`
-      : fnName(type.fqn);
+      : `module.exports.${fnName(type.fqn)}`;
   }
   return undefined;
 }
@@ -839,7 +835,7 @@ function createTypeHandlerCall(
         ),
         ts.factory.createExpressionStatement(
           ts.factory.createCallExpression(
-            ts.factory.createPropertyAccessExpression(ts.factory.createIdentifier('module.exports'), functionName),
+            ts.factory.createIdentifier(functionName),
             undefined,
             [ts.factory.createIdentifier(parameter)],
           ),

--- a/src/transforms/deprecation-warnings.ts
+++ b/src/transforms/deprecation-warnings.ts
@@ -834,11 +834,9 @@ function createTypeHandlerCall(
           ),
         ),
         ts.factory.createExpressionStatement(
-          ts.factory.createCallExpression(
-            ts.factory.createIdentifier(functionName),
-            undefined,
-            [ts.factory.createIdentifier(parameter)],
-          ),
+          ts.factory.createCallExpression(ts.factory.createIdentifier(functionName), undefined, [
+            ts.factory.createIdentifier(parameter),
+          ]),
         ),
       );
   }

--- a/test/__snapshots__/integration.test.ts.snap
+++ b/test/__snapshots__/integration.test.ts.snap
@@ -239,7 +239,12 @@ exports[`integration test: @scope/jsii-calc-base 1`] = `
           },
           "name": "veryBaseProps",
           "type": {
-            "fqn": "@scope/jsii-calc-base-of-base.VeryBaseProps",
+            "collection": {
+              "elementtype": {
+                "fqn": "@scope/jsii-calc-base-of-base.VeryBaseProps",
+              },
+              "kind": "array",
+            },
           },
         },
       ],

--- a/test/deprecation-warnings.test.ts
+++ b/test/deprecation-warnings.test.ts
@@ -440,8 +440,8 @@ class DeprecationError extends Error {
     }, 120_000);
 
     // This code never did what it said it would do. The current code is not
-    // generating calls into validation routines of other assemblies.
-    test.skip('generates calls for types in other assemblies', async () => {
+    // generating calls into validation routines of other assemblies
+    test('generates calls for types in other assemblies', async () => {
       compile(lock!, '@scope/jsii-calc-base-of-base', true);
       const calcBaseRoot = compile(lock!, '@scope/jsii-calc-base', true);
       compile(lock!, '@scope/jsii-calc-lib', true, 'deprecated-to-strip.txt');
@@ -450,7 +450,22 @@ class DeprecationError extends Error {
       // jsii-calc-base was compiled with warnings, and references a type in jsii-calc-base-of-base.
       // So we expect to see handlers for its types in the warnings file
       // and we expect it to call into base-of-base.
-      expect(warningsFile).toMatch('_scope_jsii_calc_base');
+      expect(extractFunction(warningsFile, '_scope_jsii_calc_base_TypeToContainVeryBaseProps')).toMatchInlineSnapshot(`
+        "function _scope_jsii_calc_base_TypeToContainVeryBaseProps(p) {
+                if (p == null)
+                    return;
+                visitedObjects.add(p);
+                try {
+                    if (p.veryBaseProps != null)
+                        for (const o of p.veryBaseProps)
+                            if (!visitedObjects.has(o))
+                                require("@scope/jsii-calc-base-of-base/.warnings.jsii.js")._scope_jsii_calc_base_of_base_VeryBaseProps(o);
+                }
+                finally {
+                    visitedObjects.delete(p);
+                }
+            } "
+      `);
 
       // Recompiling without deprecation warning to leave the packages in a clean state
       compile(lock!, '@scope/jsii-calc-base', false);
@@ -906,7 +921,10 @@ function jsFile(result: HelperCompilationResult, baseName = 'index'): string {
 
 function jsFunction(result: HelperCompilationResult, functionName: string, baseName = 'index'): string {
   const contents = jsFile(result, baseName);
+  return extractFunction(contents, functionName);
+}
 
+function extractFunction(contents: string, functionName: string): string {
   const needle = `function ${functionName}(p) {`;
   const startIndex = contents.indexOf(needle);
   if (startIndex < 0) {


### PR DESCRIPTION
In #2620, we changed how the deprecation warnings file is generated.

We then made the observation that everything was in place to generate validation calls to other assemblies, but that they weren't used.

That wasn't entirely true:

- `TypeFromOtherAssembly`: not validated.
- `TypeFromOtherAssembly[]`: validated.
- `TypeFromOtherAssembly | string`: validated.

It's unclear if this was intentional or not, but it is the current behavior.

And the refactoring we did in the previous PR broke the code get gets emitted for the cases in which we *do* generate the cross-assembly call.

Fix the bug, uncomment the test, and document the current behavior.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0