### PR TITLE
chore: fix Yarn Berry issue in release and upgrade workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           ref: ${{ github.ref }}
           repository: ${{ github.repository }}
+      - name: Fetch main for yarn version
+        run: git fetch --depth=1 origin main:main
       - name: Enable corepack
         run: corepack enable
       - name: Setup Node.js

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -276,7 +276,7 @@
           "exec": "yarn install --no-immutable"
         },
         {
-          "exec": "yarn up"
+          "exec": "yarn up -R"
         },
         {
           "exec": "yarn projen"

--- a/projenrc/release.ts
+++ b/projenrc/release.ts
@@ -60,6 +60,13 @@ export class ReleaseWorkflow {
         github.WorkflowSteps.checkout({
           with: { ref: '${{ github.ref }}', repository: '${{ github.repository }}' },
         }),
+        {
+          // `yarn version` needs a common ancestor with `main` to determine the
+          // release strategy. The default checkout is shallow and tag-only, so
+          // we fetch the tip of `main` to give yarn an ancestor to diff against.
+          name: 'Fetch main for yarn version',
+          run: 'git fetch --depth=1 origin main:main',
+        },
         ...workflowSetup(this.project),
         {
           name: 'Prepare Release',

--- a/projenrc/upgrade-dependencies.ts
+++ b/projenrc/upgrade-dependencies.ts
@@ -355,7 +355,7 @@ export class UpgradeDependencies extends Component {
         break;
       case NodePackageManager.YARN2:
       case NodePackageManager.YARN_BERRY:
-        lazy = upgradePackages('yarn up');
+        lazy = upgradePackages('yarn up -R');
         break;
       case NodePackageManager.NPM:
         lazy = upgradePackages('npm update');


### PR DESCRIPTION
Fixes two release-adjacent workflows that broke after the migration to Yarn Berry (#2626).

The release workflow has been failing on every tag push (e.g. [run 24753564993](https://github.com/aws/jsii-compiler/actions/runs/24753564993)) because Yarn Berry's `yarn version` command requires a common ancestor with `main` (or `master`) to determine the release strategy. The release job uses a shallow, tag-only checkout which does not bring in any branch ref, so Yarn errors out with "No ancestor could be found between any of HEAD and master, origin/master, upstream/master, main, origin/main, upstream/main". Yarn Classic's `yarn version --new-version` had no such requirement, which is why the workflow worked before. Fetching a single-commit snapshot of `main` right after checkout gives Yarn the ancestor it needs without materially increasing the workflow's data cost.

Separately, the dependency upgrade workflow silently regressed in scope. Yarn Classic's `yarn upgrade` recursed into transitive dependents and bumped them alongside direct ones, while Yarn Berry's `yarn up` only upgrades the top-level range by default. Without `-R`, the upgrade PRs opened by this repo only refresh direct dependencies, leaving transitive graph entries stale. Passing `-R` restores the previous behavior.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
