### PR TITLE
fix: packages not released with npm provenance attestations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,7 @@ jobs:
           name: .repo.patch
           path: .repo.patch
           overwrite: true
+          include-hidden-files: true
       - name: Fail if self-mutation is needed
         if: steps.self-mutation.outputs.needed
         run: |-
@@ -190,6 +191,7 @@ jobs:
           name: release-package
           path: ${{ github.workspace }}/dist
           overwrite: true
+          include-hidden-files: true
   install-test:
     name: Install Test (${{ matrix.runs-on }} | node ${{ matrix.node-version }} | ${{ matrix.package-manager }})
     needs: package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,7 @@ jobs:
             !${{ github.workspace }}/node_modules
             !${{ github.workspace }}/fixtures/node_modules
           overwrite: true
+          include-hidden-files: true
       - name: Version Line
         id: version
         run: |-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
           git diff --cached --patch --exit-code > .repo.patch || echo "needed=true" >> $GITHUB_OUTPUT
       - name: Upload patch
         if: steps.self-mutation.outputs.needed
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v7
         with:
           name: .repo.patch
           path: .repo.patch
@@ -64,7 +64,7 @@ jobs:
           cat .repo.patch
           exit 1
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v7
         with:
           name: build-output
           path: |-
@@ -94,7 +94,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Download patch
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: .repo.patch
           path: ${{ runner.temp }}
@@ -119,14 +119,14 @@ jobs:
     if: success()
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-output
           path: ${{ github.workspace }}
       - name: Enable corepack
         run: corepack enable
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
@@ -168,7 +168,7 @@ jobs:
       CI: "true"
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-output
           path: ${{ github.workspace }}
@@ -184,7 +184,7 @@ jobs:
       - name: Package
         run: npx projen package
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v7
         with:
           name: release-package
           path: ${{ github.workspace }}/dist
@@ -198,11 +198,11 @@ jobs:
       CI: "true"
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - name: Download Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-package
           path: ${{ runner.temp }}/release-package
@@ -253,9 +253,9 @@ jobs:
       CI: "true"
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
       - name: Download Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-package
           path: ${{ runner.temp }}/release-package
@@ -337,7 +337,7 @@ jobs:
           node-version: lts/*
           package-manager-cache: false
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-output
       - name: Install dependencies
@@ -442,7 +442,7 @@ jobs:
           EOF
       - name: Authenticate Via OIDC Role
         if: github.event.repository.fork == false && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/maintenance/v'))
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: us-east-1
           role-duration-seconds: 900

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         run: yarn ts-node projenrc/publish-target.ts ${{ github.ref_name }}
       - name: Federate to AWS
         if: fromJSON(steps.publish-target.outputs.github-release)
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: us-east-1
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
@@ -73,7 +73,7 @@ jobs:
           unset passphrase
           find ${GNUPGHOME} -type f -exec shred --remove {} \;
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v7
         with:
           name: release-package
           path: ${{ github.workspace }}/dist
@@ -89,7 +89,7 @@ jobs:
     if: fromJSON(needs.build.outputs.github-release)
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-package
       - name: Verify if release exists
@@ -128,19 +128,18 @@ jobs:
       CI: "true"
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-package
       - name: Enable corepack
         run: corepack enable
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          always-auth: true
           node-version: lts/*
           registry-url: https://registry.npmjs.org/
       - name: Federate to AWS
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: us-east-1
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
@@ -154,7 +153,7 @@ jobs:
           echo "NODE_AUTH_TOKEN=${token}" >> $GITHUB_ENV
           unset token
       - name: Publish
-        run: npm publish ${{ github.workspace }}/js/jsii-*.tgz --access=public --tag=${{ needs.build.outputs.dist-tag }}
+        run: npm publish ${{ github.workspace }}/js/jsii-*.tgz --access=public --provenance --tag=${{ needs.build.outputs.dist-tag }}
       - name: Tag "latest"
         if: fromJSON(needs.build.outputs.latest)
         run: npm dist-tag add jsii@${{ github.ref_name }} latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,7 @@ jobs:
           name: release-package
           path: ${{ github.workspace }}/dist
           overwrite: true
+          include-hidden-files: true
   release-to-github:
     name: Create GitHub Release
     needs: build

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -15,7 +15,7 @@ jobs:
       patch_created: ${{ steps.create_patch.outputs.patch_created }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
       - name: Enable corepack

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ jspm_packages/
 /jsii-outdir/
 /test/negatives/.*
 .DS_Store
+.lock
 !/.github/workflows/build.yml
 !/.github/workflows/auto-merge.yml
 !/.github/workflows/release.yml

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -242,7 +242,7 @@ project.preCompileTask.exec('ts-node build-tools/code-gen.ts', {
   name: 'code-gen',
 });
 project.gitignore.addPatterns('/src/version.ts', '/jsii-outdir/', '/test/negatives/.*');
-project.gitignore.exclude('.DS_Store');
+project.gitignore.exclude('.DS_Store', '.lock');
 
 // Exclude negatives from tsconfig and eslint...
 project.tsconfigDev.addExclude('test/negatives/**/*.ts');

--- a/projenrc/benchmark-test.ts
+++ b/projenrc/benchmark-test.ts
@@ -53,7 +53,7 @@ export class BenchmarkTest {
           },
           {
             name: 'Download artifact',
-            uses: 'actions/download-artifact@v4',
+            uses: 'actions/download-artifact@v8',
             with: { name: artifactName },
           },
           { name: 'Install dependencies', run: 'yarn install --immutable' },
@@ -136,7 +136,7 @@ export class BenchmarkTest {
           {
             name: 'Authenticate Via OIDC Role',
             if: `github.event.repository.fork == false && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/maintenance/v'))`,
-            uses: 'aws-actions/configure-aws-credentials@v4',
+            uses: 'aws-actions/configure-aws-credentials@v6',
             with: {
               'aws-region': 'us-east-1',
               'role-duration-seconds': 900,

--- a/projenrc/build-workflow.ts
+++ b/projenrc/build-workflow.ts
@@ -91,9 +91,10 @@ export class BuildWorkflow {
             if: 'steps.self-mutation.outputs.needed',
             uses: 'actions/upload-artifact@v7',
             with: {
-              name: '.repo.patch',
-              path: '.repo.patch',
-              overwrite: true,
+              'name': '.repo.patch',
+              'path': '.repo.patch',
+              'overwrite': true,
+              'include-hidden-files': true,
             },
           },
           {
@@ -270,9 +271,10 @@ export class BuildWorkflow {
             name: 'Upload artifact',
             uses: 'actions/upload-artifact@v7',
             with: {
-              name: 'release-package',
-              path: '${{ github.workspace }}/dist',
-              overwrite: true,
+              'name': 'release-package',
+              'path': '${{ github.workspace }}/dist',
+              'overwrite': true,
+              'include-hidden-files': true,
             },
           },
         ],

--- a/projenrc/build-workflow.ts
+++ b/projenrc/build-workflow.ts
@@ -111,15 +111,16 @@ export class BuildWorkflow {
             name: 'Upload artifact',
             uses: 'actions/upload-artifact@v7',
             with: {
-              name: 'build-output',
-              path: [
+              'name': 'build-output',
+              'path': [
                 '${{ github.workspace }}',
                 '${{ github.workspace }}/dist/private',
                 // Exclude node_modules to reduce artifact size (we won't use those anyway)...
                 '!${{ github.workspace }}/node_modules',
                 '!${{ github.workspace }}/fixtures/node_modules',
               ].join('\n'),
-              overwrite: true,
+              'overwrite': true,
+              'include-hidden-files': true,
             },
           },
           {

--- a/projenrc/build-workflow.ts
+++ b/projenrc/build-workflow.ts
@@ -89,7 +89,7 @@ export class BuildWorkflow {
           {
             name: 'Upload patch',
             if: 'steps.self-mutation.outputs.needed',
-            uses: 'actions/upload-artifact@v4.3.6',
+            uses: 'actions/upload-artifact@v7',
             with: {
               name: '.repo.patch',
               path: '.repo.patch',
@@ -109,7 +109,7 @@ export class BuildWorkflow {
           // Upload artifacts...
           {
             name: 'Upload artifact',
-            uses: 'actions/upload-artifact@v4.3.6',
+            uses: 'actions/upload-artifact@v7',
             with: {
               name: 'build-output',
               path: [
@@ -148,7 +148,7 @@ export class BuildWorkflow {
           }),
           {
             name: 'Download patch',
-            uses: 'actions/download-artifact@v4',
+            uses: 'actions/download-artifact@v8',
             with: {
               name: '.repo.patch',
               path: '${{ runner.temp }}',
@@ -197,7 +197,7 @@ export class BuildWorkflow {
         steps: [
           {
             name: 'Download artifact',
-            uses: 'actions/download-artifact@v4',
+            uses: 'actions/download-artifact@v8',
             with: { name: 'build-output', path: '${{ github.workspace }}' },
           },
           {
@@ -206,7 +206,7 @@ export class BuildWorkflow {
           },
           {
             name: 'Setup Node.js',
-            uses: 'actions/setup-node@v4',
+            uses: 'actions/setup-node@v6',
             with: {
               'node-version': '${{ matrix.node-version }}',
               'cache': 'yarn',
@@ -257,7 +257,7 @@ export class BuildWorkflow {
         steps: [
           {
             name: 'Download artifact',
-            uses: 'actions/download-artifact@v4',
+            uses: 'actions/download-artifact@v8',
             with: { name: 'build-output', path: '${{ github.workspace }}' },
           },
           ...workflowSetup(project),
@@ -267,7 +267,7 @@ export class BuildWorkflow {
           },
           {
             name: 'Upload artifact',
-            uses: 'actions/upload-artifact@v4.3.6',
+            uses: 'actions/upload-artifact@v7',
             with: {
               name: 'release-package',
               path: '${{ github.workspace }}/dist',
@@ -301,12 +301,12 @@ export class BuildWorkflow {
         steps: [
           {
             name: 'Setup Node.js',
-            uses: 'actions/setup-node@v4',
+            uses: 'actions/setup-node@v6',
             with: { 'node-version': '${{ matrix.node-version }}' },
           },
           {
             name: 'Download Artifact',
-            uses: 'actions/download-artifact@v4',
+            uses: 'actions/download-artifact@v8',
             with: {
               name: 'release-package',
               path: '${{ runner.temp }}/release-package',
@@ -356,11 +356,11 @@ export class BuildWorkflow {
         steps: [
           {
             name: 'Setup Node.js',
-            uses: 'actions/setup-node@v4',
+            uses: 'actions/setup-node@v6',
           },
           {
             name: 'Download Artifact',
-            uses: 'actions/download-artifact@v4',
+            uses: 'actions/download-artifact@v8',
             with: {
               name: 'release-package',
               path: '${{ runner.temp }}/release-package',

--- a/projenrc/release.ts
+++ b/projenrc/release.ts
@@ -32,7 +32,7 @@ export class ReleaseWorkflow {
     const publishTarget = 'publish-target';
     const federateToAwsStep: github.workflows.JobStep = {
       name: 'Federate to AWS',
-      uses: 'aws-actions/configure-aws-credentials@v1',
+      uses: 'aws-actions/configure-aws-credentials@v6',
       with: {
         'aws-region': 'us-east-1',
         'role-to-assume': '${{ secrets.AWS_ROLE_TO_ASSUME }}',
@@ -118,7 +118,7 @@ export class ReleaseWorkflow {
         },
         {
           name: 'Upload artifact',
-          uses: 'actions/upload-artifact@v4.3.6',
+          uses: 'actions/upload-artifact@v7',
           with: {
             name: releasePackageName,
             path: '${{ github.workspace }}/dist',
@@ -130,7 +130,7 @@ export class ReleaseWorkflow {
 
     const downloadArtifactStep: github.workflows.JobStep = {
       name: 'Download artifact',
-      uses: 'actions/download-artifact@v4',
+      uses: 'actions/download-artifact@v8',
       with: {
         name: releasePackageName,
       },
@@ -229,9 +229,8 @@ export class ReleaseWorkflow {
         },
         {
           name: 'Setup Node.js',
-          uses: 'actions/setup-node@v4',
+          uses: 'actions/setup-node@v6',
           with: {
-            'always-auth': true,
             'node-version': nodeVersion,
             'registry-url': `https://registry.npmjs.org/`,
           },
@@ -253,6 +252,7 @@ export class ReleaseWorkflow {
           run: [
             'npm publish ${{ github.workspace }}/js/jsii-*.tgz',
             '--access=public',
+            '--provenance',
             `--tag=\${{ needs.build.outputs.${PublishTargetOutput.DIST_TAG} }}`,
           ].join(' '),
         },

--- a/projenrc/release.ts
+++ b/projenrc/release.ts
@@ -120,9 +120,10 @@ export class ReleaseWorkflow {
           name: 'Upload artifact',
           uses: 'actions/upload-artifact@v7',
           with: {
-            name: releasePackageName,
-            path: '${{ github.workspace }}/dist',
-            overwrite: true,
+            'name': releasePackageName,
+            'path': '${{ github.workspace }}/dist',
+            'overwrite': true,
+            'include-hidden-files': true,
           },
         },
       ],

--- a/projenrc/upgrade-dependencies.ts
+++ b/projenrc/upgrade-dependencies.ts
@@ -260,7 +260,7 @@ export class UpgradeDependencies extends Component {
     const steps: github.workflows.JobStep[] = [
       {
         name: 'Checkout',
-        uses: 'actions/checkout@v4',
+        uses: 'actions/checkout@v6',
         with: Object.keys(with_).length > 0 ? with_ : undefined,
       },
       ...this._project.renderWorkflowSetup({ mutable: false }),


### PR DESCRIPTION
Adds npm provenance attestations to the release workflow via `--provenance`, enabling consumers to verify packages were built from this repository's CI.

Also updates all GitHub Actions to their latest Node 24 compatible major versions before the June 2, 2026 deadline, and removes the deprecated `always-auth` input from `actions/setup-node@v6`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0