### PR TITLE
fix: reject unions with multiple array members

### DIFF
--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -2381,6 +2381,23 @@ export class Assembler implements Emitter {
         types.push(resolvedType);
       }
 
+      if (field === 'union') {
+        const arrayTypes = types.filter(
+          (ref) => spec.isCollectionTypeReference(ref) && ref.collection.kind === spec.CollectionKind.Array,
+        );
+
+        if (arrayTypes.length > 1) {
+          this._diagnostics.push(
+            JsiiDiagnostic.JSII_1003_UNSUPPORTED_TYPE.create(
+              declaration,
+              `Union types cannot contain multiple array types (${arrayTypes
+                .map(typeReferenceToString)
+                .join(', ')}). Use an array whose element type is a union instead.`,
+            ),
+          );
+        }
+      }
+
       const returnedType: spec.UnionTypeReference | spec.IntersectionTypeReference = {
         [field]: { types },
       } as any;

--- a/test/type-alias.test.ts
+++ b/test/type-alias.test.ts
@@ -1,5 +1,6 @@
 import { PrimitiveType, Type, TypeKind } from '@jsii/spec';
-import { sourceToAssemblyHelper } from '../lib';
+import { DiagnosticCategory } from 'typescript';
+import { compileJsiiForTest, sourceToAssemblyHelper } from '../lib';
 
 // ----------------------------------------------------------------------
 test('type aliases with awaited and promise types', () => {
@@ -79,4 +80,57 @@ test('type aliases with awaited and promise types', () => {
     ],
     symbolId: 'index:AwaitedPromiseTypes',
   } satisfies Type);
+});
+
+test('type aliases reject unions containing multiple array members', () => {
+  const result = compileJsiiForTest(
+    `
+    export class A {}
+    export class B {}
+    export class C {}
+
+    export type X = A[] | B[] | C;
+
+    export class UsesX {
+      public constructor(public readonly value: X) {}
+    }
+    `,
+    { captureDiagnostics: true },
+  );
+
+  expect(result.type).toBe('failure');
+  expect(result.diagnostics).toContainEqual(
+    expect.objectContaining({
+      category: DiagnosticCategory.Error,
+      messageText: expect.stringContaining('Union types cannot contain multiple array types'),
+    }),
+  );
+});
+
+test('type aliases allow union element arrays inside broader unions', () => {
+  const assembly = sourceToAssemblyHelper(`
+    export class A {}
+    export class B {}
+    export class C {}
+
+    export type X = (A | B)[] | C;
+
+    export class UsesX {
+      public constructor(public readonly value: X) {}
+    }
+  `);
+
+  const unionTypes = assembly.types!['testpkg.UsesX'].initializer!.parameters![0].type.union!.types;
+
+  expect(unionTypes).toContainEqual({ fqn: 'testpkg.C' });
+  expect(unionTypes).toContainEqual({
+    collection: {
+      elementtype: {
+        union: {
+          types: [{ fqn: 'testpkg.A' }, { fqn: 'testpkg.B' }],
+        },
+      },
+      kind: 'array',
+    },
+  });
 });


### PR DESCRIPTION
## Summary

Fixes aws/jsii#5087.

Reject union type references that contain more than one array member at the same union level, such as `A[] | B[] | C`. These unions can pass jsii compilation today but fail later in Java packaging because the array members cannot be represented distinctly after type erasure.

## Changes

- Emit a `JSII_1003_UNSUPPORTED_TYPE` diagnostic when a union contains multiple array collection members.
- Keep `(A | B)[] | C` valid by only checking sibling array members in the same union.
- Add regression coverage for the rejected and accepted forms.

## Testing

- `yarn projen && yarn pre-compile && yarn compile`
- `yarn jest test/type-alias.test.ts -t 'multiple array members' --runInBand` (failed before the fix; passed after)
- `yarn compile && yarn jest test/type-alias.test.ts -t 'multiple array members|union element arrays' --runInBand`
- `yarn jest test/type-alias.test.ts --runInBand`
- `yarn eslint src/assembler.ts test/type-alias.test.ts`
- `yarn post-compile && yarn test`
- `git diff --check`

Note: I used Codex while preparing this change, and I reviewed the final diff and ran the listed checks locally.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
