### PR TITLE
feat: add commands to validate a tsconfig and inspect tsconfig rule sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,48 @@ Here's a collection of blog posts (in chronological order) related to `jsii`:
 > :information_source: If you wrote blog posts about `jsii` and would like to have them referenced here, do not hesitate
 > to file a pull request to add the links here!
 
+## :triangular_ruler: Inspecting & Validating tsconfig
+
+When you provide your own `tsconfig.json` (via `--tsconfig`), `jsii` validates its `compilerOptions` against a
+[rule set](#arrow_up-upgrading-to-jsii-60) (`strict` by default). Two commands let you inspect those rule sets and
+validate a configuration file directly, without running a full compilation.
+
+### `jsii rules`
+
+Prints the validation rules for a rule set, so you can see exactly what each setting enforces:
+
+```sh
+# Print the rules for the strict rule set
+jsii rules strict
+
+# Print the rules for all rule sets (strict, generated, minimal, off)
+jsii rules
+```
+
+The output lists, per `compilerOptions` field, whether it must be present and what values are allowed (or disallowed),
+and whether unknown options are rejected for that rule set.
+
+### `jsii validate-tsconfig`
+
+Validates an existing TypeScript configuration file against a rule set and reports any violations. It exits with a
+non-zero status when validation fails, which makes it suitable for use in CI or pre-commit checks:
+
+```sh
+# Validate ./tsconfig.json against the strict rule set (the default)
+jsii validate-tsconfig
+
+# Validate a specific file
+jsii validate-tsconfig tsconfig.dev.json
+
+# Validate against a different rule set (--rule-set, alias -R)
+jsii validate-tsconfig tsconfig.json --rule-set generated
+jsii validate-tsconfig tsconfig.json -R minimal
+```
+
+The available rule sets are `strict`, `generated`, `minimal`, and `off`. They behave exactly as the `--validate-tsconfig`
+option does during compilation; see [Upgrading to jsii 6.0](#arrow_up-upgrading-to-jsii-60) for guidance on the rules
+each set enforces.
+
 ## :mute: Silencing Warnings
 
 The `--silence-warnings` option allows you to suppress specific warnings from the compiler output. Silenced warnings

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,12 +12,8 @@ import { configureCategories, JsiiDiagnostic } from './jsii-diagnostic';
 import { loadProjectInfo } from './project-info';
 import { emitSupportPolicyInformation } from './support';
 import { TypeScriptConfigValidationRuleSet } from './tsconfig';
-import {
-  describeRuleSet,
-  getCompilerOptionsRuleSet,
-  validateTypeScriptConfigFile,
-} from './tsconfig/tsconfig-validator';
-import { RuleDescription, RuleType } from './tsconfig/validator';
+import { formatRuleSet, RULE_SET_DESCRIPTIONS } from './tsconfig/rule-set-format';
+import { validateTypeScriptConfigFile } from './tsconfig/tsconfig-validator';
 import * as utils from './utils';
 import { VERSION } from './version';
 import { parseWarningCodes, silencedWarnings } from './warnings';
@@ -39,19 +35,6 @@ enum OPTION_GROUP {
   JSII = 'jsii compiler options:',
   TS = 'TypeScript config options:',
 }
-
-const ruleSets: {
-  [choice in TypeScriptConfigValidationRuleSet]: string;
-} = {
-  [TypeScriptConfigValidationRuleSet.STRICT]:
-    'Validates the provided config against a strict rule set designed for maximum backwards-compatibility.',
-  [TypeScriptConfigValidationRuleSet.GENERATED]:
-    'Enforces a config as created by --generate-tsconfig. Use this to stay compatible with the generated config, but have full ownership over the file.',
-  [TypeScriptConfigValidationRuleSet.MINIMAL]:
-    'Only enforce options that are known to be incompatible with jsii. This rule set is likely to be incomplete and new rules will be added without notice as incompatibilities emerge.',
-  [TypeScriptConfigValidationRuleSet.NONE]:
-    'Disables all config validation, including options that are known to be incompatible with jsii. Intended for experimentation only. Use at your own risk.',
-};
 
 (async () => {
   await emitSupportPolicyInformation();
@@ -125,7 +108,10 @@ const ruleSets: {
           .conflicts('tsconfig', ['generate-tsconfig', 'project-references'])
           .option('validate-tsconfig', {
             group: OPTION_GROUP.TS,
-            ...choiceWithDesc(ruleSets, 'Validate the provided typescript configuration file against a set of rules.'),
+            ...choiceWithDesc(
+              RULE_SET_DESCRIPTIONS,
+              'Validate the provided typescript configuration file against a set of rules.',
+            ),
             defaultDescription: TypeScriptConfigValidationRuleSet.STRICT,
           })
           .option('compress-assembly', {
@@ -226,7 +212,7 @@ const ruleSets: {
           .option('rule-set', {
             group: OPTION_GROUP.TS,
             alias: 'R',
-            ...choiceWithDesc(ruleSets, 'The rule set to validate the configuration file against.'),
+            ...choiceWithDesc(RULE_SET_DESCRIPTIONS, 'The rule set to validate the configuration file against.'),
             default: TypeScriptConfigValidationRuleSet.STRICT,
           }),
       (argv) => {
@@ -274,7 +260,7 @@ const ruleSets: {
       'Print the tsconfig validation rules for a rule set (or for all rule sets)',
       (cmd) =>
         cmd.positional('RULE_SET', {
-          ...choiceWithDesc(ruleSets, 'The rule set to print. If omitted, all rule sets are printed.'),
+          ...choiceWithDesc(RULE_SET_DESCRIPTIONS, 'The rule set to print. If omitted, all rule sets are printed.'),
         }),
       (argv) => {
         const selected = argv.RULE_SET as TypeScriptConfigValidationRuleSet | undefined;
@@ -283,7 +269,7 @@ const ruleSets: {
             ? [selected]
             : (Object.values(TypeScriptConfigValidationRuleSet) as TypeScriptConfigValidationRuleSet[]);
 
-        console.log(sets.map(formatRuleSet).join(`\n\n${chalk.dim('─'.repeat(72))}\n\n`));
+        console.log(`${sets.map(formatRuleSet).join(`\n\n${chalk.dim('─'.repeat(72))}\n\n`)}\n`);
       },
     )
     .help()
@@ -351,82 +337,4 @@ function _configureLog4js(verbosity: number) {
         return 'ALL';
     }
   }
-}
-
-/**
- * Render a single rule set (its `compilerOptions` rules) as a human-readable block.
- */
-function formatRuleSet(ruleSet: TypeScriptConfigValidationRuleSet): string {
-  const lines: string[] = [`${chalk.bold('Rule set:')} ${chalk.bold.cyan(ruleSet)}`];
-
-  const description = ruleSets[ruleSet];
-  if (description) {
-    lines.push(chalk.dim(description));
-  }
-
-  const rules = describeRuleSet(ruleSet);
-  if (rules.length === 0) {
-    lines.push('');
-    lines.push(chalk.dim('  No rules. Configuration validation is disabled for this rule set.'));
-    return lines.join('\n');
-  }
-
-  const unknownRejected = getCompilerOptionsRuleSet(ruleSet).options.unexpectedFields === RuleType.FAIL;
-  lines.push('');
-  lines.push(chalk.dim(`Applies to: compilerOptions (unknown options: ${unknownRejected ? 'rejected' : 'allowed'})`));
-  lines.push('');
-
-  // Group rules by field, preserving the order in which each field first appears.
-  const byField = new Map<string, RuleDescription[]>();
-  for (const rule of rules) {
-    const list = byField.get(rule.field) ?? [];
-    list.push(rule);
-    byField.set(rule.field, list);
-  }
-
-  const width = Math.max(...[...byField.keys()].map((field) => field.length));
-  for (const [field, fieldRules] of byField) {
-    const phrases = fieldRules.map(formatConstraint);
-    // A required field is surfaced as an explicit "must be present" constraint.
-    if (fieldRules.some((rule) => rule.required)) {
-      phrases.unshift('must be present');
-    }
-    // Dedupe identical phrases (some fields are constrained by several rules that overlap).
-    const constraints = [...new Set(phrases)].join('; ');
-    lines.push(`  ${chalk.bold(field.padEnd(width))}  ${constraints}`);
-  }
-
-  return lines.join('\n');
-}
-
-/**
- * Render a single rule's constraint as a human-readable phrase.
- */
-function formatConstraint(rule: RuleDescription): string {
-  const { type, values } = rule;
-
-  // No hints means the matcher accepts anything (e.g. Match.ANY).
-  if (values === undefined) {
-    return type === RuleType.PASS ? 'any value allowed' : 'must not be set to the matched value';
-  }
-
-  // Only null/undefined hints means the option must be absent (e.g. Match.MISSING).
-  if (values.length > 0 && values.every((value) => value == null)) {
-    return 'not allowed';
-  }
-
-  const formatted = values.map(formatRuleValue);
-  if (type === RuleType.FAIL) {
-    return formatted.length > 1 ? `must not be one of: ${formatted.join(', ')}` : `must not be ${formatted[0]}`;
-  }
-  return formatted.length > 1 ? `must be one of: ${formatted.join(', ')}` : `must be ${formatted[0]}`;
-}
-
-/**
- * Render a single hinted value as a highlighted code literal. Strings are shown
- * verbatim (as a user writes them in tsconfig.json), everything else is JSON-encoded.
- */
-function formatRuleValue(value: any): string {
-  const literal = typeof value === 'string' ? value : JSON.stringify(value);
-  return chalk.cyan(literal);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,15 +2,22 @@ import '@jsii/check-node/run';
 
 import * as path from 'node:path';
 import * as util from 'node:util';
+import chalk from 'chalk';
 import * as log4js from 'log4js';
 import { version as tsVersion } from 'typescript/package.json';
 import * as yargs from 'yargs';
 
 import { Compiler } from './compiler';
-import { configureCategories } from './jsii-diagnostic';
+import { configureCategories, JsiiDiagnostic } from './jsii-diagnostic';
 import { loadProjectInfo } from './project-info';
 import { emitSupportPolicyInformation } from './support';
 import { TypeScriptConfigValidationRuleSet } from './tsconfig';
+import {
+  describeRuleSet,
+  getCompilerOptionsRuleSet,
+  validateTypeScriptConfigFile,
+} from './tsconfig/tsconfig-validator';
+import { RuleDescription, RuleType } from './tsconfig/validator';
 import * as utils from './utils';
 import { VERSION } from './version';
 import { parseWarningCodes, silencedWarnings } from './warnings';
@@ -205,6 +212,80 @@ const ruleSets: {
         }
       },
     )
+    .command(
+      'validate-tsconfig [TSCONFIG]',
+      'Validate a TypeScript configuration file against a jsii rule set, without compiling',
+      (cmd) =>
+        cmd
+          .positional('TSCONFIG', {
+            type: 'string',
+            desc: 'The TypeScript configuration file to validate',
+            default: 'tsconfig.json',
+            normalize: true,
+          })
+          .option('rule-set', {
+            group: OPTION_GROUP.TS,
+            alias: 'R',
+            ...choiceWithDesc(ruleSets, 'The rule set to validate the configuration file against.'),
+            default: TypeScriptConfigValidationRuleSet.STRICT,
+          }),
+      (argv) => {
+        try {
+          const verbosity = typeof argv.verbose === 'number' ? argv.verbose : 0;
+          _configureLog4js(verbosity);
+
+          const configPath = path.resolve(process.cwd(), argv.TSCONFIG);
+          const projectRoot = path.dirname(configPath);
+          const configName = path.relative(projectRoot, configPath);
+          const ruleSet = argv['rule-set'] as TypeScriptConfigValidationRuleSet;
+
+          // Validation is disabled for the "off" rule set; mirror the compiler behavior.
+          if (ruleSet === TypeScriptConfigValidationRuleSet.NONE) {
+            utils.logDiagnostic(
+              JsiiDiagnostic.JSII_4009_DISABLED_TSCONFIG_VALIDATION.create(undefined, configName),
+              projectRoot,
+            );
+            return;
+          }
+
+          const violations = validateTypeScriptConfigFile(configPath, ruleSet);
+          if (violations.length > 0) {
+            utils.logDiagnostic(
+              JsiiDiagnostic.JSII_4000_FAILED_TSCONFIG_VALIDATION.create(undefined, configName, ruleSet, violations),
+              projectRoot,
+            );
+            process.exitCode = 1;
+          } else {
+            console.log(`✨ "${configName}" is valid against rule set "${ruleSet}"`);
+          }
+        } catch (e: unknown) {
+          if (e instanceof utils.JsiiError) {
+            const LOG = log4js.getLogger(utils.CLI_LOGGER);
+            LOG.error(e.message);
+            process.exitCode = -1;
+          } else {
+            throw e;
+          }
+        }
+      },
+    )
+    .command(
+      'rules [RULE_SET]',
+      'Print the tsconfig validation rules for a rule set (or for all rule sets)',
+      (cmd) =>
+        cmd.positional('RULE_SET', {
+          ...choiceWithDesc(ruleSets, 'The rule set to print. If omitted, all rule sets are printed.'),
+        }),
+      (argv) => {
+        const selected = argv.RULE_SET as TypeScriptConfigValidationRuleSet | undefined;
+        const sets =
+          selected != null
+            ? [selected]
+            : (Object.values(TypeScriptConfigValidationRuleSet) as TypeScriptConfigValidationRuleSet[]);
+
+        console.log(sets.map(formatRuleSet).join(`\n\n${chalk.dim('─'.repeat(72))}\n\n`));
+      },
+    )
     .help()
     .version(`${VERSION}, typescript ${tsVersion}`)
     .parse();
@@ -270,4 +351,82 @@ function _configureLog4js(verbosity: number) {
         return 'ALL';
     }
   }
+}
+
+/**
+ * Render a single rule set (its `compilerOptions` rules) as a human-readable block.
+ */
+function formatRuleSet(ruleSet: TypeScriptConfigValidationRuleSet): string {
+  const lines: string[] = [`${chalk.bold('Rule set:')} ${chalk.bold.cyan(ruleSet)}`];
+
+  const description = ruleSets[ruleSet];
+  if (description) {
+    lines.push(chalk.dim(description));
+  }
+
+  const rules = describeRuleSet(ruleSet);
+  if (rules.length === 0) {
+    lines.push('');
+    lines.push(chalk.dim('  No rules. Configuration validation is disabled for this rule set.'));
+    return lines.join('\n');
+  }
+
+  const unknownRejected = getCompilerOptionsRuleSet(ruleSet).options.unexpectedFields === RuleType.FAIL;
+  lines.push('');
+  lines.push(chalk.dim(`Applies to: compilerOptions (unknown options: ${unknownRejected ? 'rejected' : 'allowed'})`));
+  lines.push('');
+
+  // Group rules by field, preserving the order in which each field first appears.
+  const byField = new Map<string, RuleDescription[]>();
+  for (const rule of rules) {
+    const list = byField.get(rule.field) ?? [];
+    list.push(rule);
+    byField.set(rule.field, list);
+  }
+
+  const width = Math.max(...[...byField.keys()].map((field) => field.length));
+  for (const [field, fieldRules] of byField) {
+    const phrases = fieldRules.map(formatConstraint);
+    // A required field is surfaced as an explicit "must be present" constraint.
+    if (fieldRules.some((rule) => rule.required)) {
+      phrases.unshift('must be present');
+    }
+    // Dedupe identical phrases (some fields are constrained by several rules that overlap).
+    const constraints = [...new Set(phrases)].join('; ');
+    lines.push(`  ${chalk.bold(field.padEnd(width))}  ${constraints}`);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Render a single rule's constraint as a human-readable phrase.
+ */
+function formatConstraint(rule: RuleDescription): string {
+  const { type, values } = rule;
+
+  // No hints means the matcher accepts anything (e.g. Match.ANY).
+  if (values === undefined) {
+    return type === RuleType.PASS ? 'any value allowed' : 'must not be set to the matched value';
+  }
+
+  // Only null/undefined hints means the option must be absent (e.g. Match.MISSING).
+  if (values.length > 0 && values.every((value) => value == null)) {
+    return 'not allowed';
+  }
+
+  const formatted = values.map(formatRuleValue);
+  if (type === RuleType.FAIL) {
+    return formatted.length > 1 ? `must not be one of: ${formatted.join(', ')}` : `must not be ${formatted[0]}`;
+  }
+  return formatted.length > 1 ? `must be one of: ${formatted.join(', ')}` : `must be ${formatted[0]}`;
+}
+
+/**
+ * Render a single hinted value as a highlighted code literal. Strings are shown
+ * verbatim (as a user writes them in tsconfig.json), everything else is JSON-encoded.
+ */
+function formatRuleValue(value: any): string {
+  const literal = typeof value === 'string' ? value : JSON.stringify(value);
+  return chalk.cyan(literal);
 }

--- a/src/tsconfig/rule-set-format.ts
+++ b/src/tsconfig/rule-set-format.ts
@@ -1,0 +1,110 @@
+import chalk from 'chalk';
+import { TypeScriptConfigValidationRuleSet } from '.';
+import { describeRuleSet, getCompilerOptionsRuleSet } from './tsconfig-validator';
+import { RuleDescription, RuleType } from './validator';
+
+/**
+ * Human-readable descriptions for each tsconfig validation rule set.
+ *
+ * These are surfaced both as CLI option help (e.g. for `--validate-tsconfig` and
+ * `--rule-set`) and as the heading when printing a rule set via `formatRuleSet`.
+ */
+export const RULE_SET_DESCRIPTIONS: {
+  [choice in TypeScriptConfigValidationRuleSet]: string;
+} = {
+  [TypeScriptConfigValidationRuleSet.STRICT]:
+    'Validates the provided config against a strict rule set designed for maximum backwards-compatibility.',
+  [TypeScriptConfigValidationRuleSet.GENERATED]:
+    'Enforces a config as created by --generate-tsconfig. Use this to stay compatible with the generated config, but have full ownership over the file.',
+  [TypeScriptConfigValidationRuleSet.MINIMAL]:
+    'Only enforce options that are known to be incompatible with jsii. This rule set is likely to be incomplete and new rules will be added without notice as incompatibilities emerge.',
+  [TypeScriptConfigValidationRuleSet.NONE]:
+    'Disables all config validation, including options that are known to be incompatible with jsii. Intended for experimentation only. Use at your own risk.',
+};
+
+/**
+ * Render a single rule set (its `compilerOptions` rules) as a human-readable block.
+ *
+ * @param ruleSet the rule set to render
+ * @returns a multi-line string suitable for printing to the console
+ */
+export function formatRuleSet(ruleSet: TypeScriptConfigValidationRuleSet): string {
+  const lines: string[] = [`${chalk.bold('Rule set:')} ${chalk.bold.cyan(ruleSet)}`];
+
+  const description = RULE_SET_DESCRIPTIONS[ruleSet];
+  if (description) {
+    lines.push(chalk.dim(description));
+  }
+
+  const rules = describeRuleSet(ruleSet);
+  if (rules.length === 0) {
+    lines.push('');
+    lines.push(chalk.dim('  No rules. Configuration validation is disabled for this rule set.'));
+    return lines.join('\n');
+  }
+
+  const unknownRejected = getCompilerOptionsRuleSet(ruleSet).options.unexpectedFields === RuleType.FAIL;
+  lines.push('');
+  lines.push(chalk.dim(`Applies to: compilerOptions (other options: ${unknownRejected ? 'rejected' : 'allowed'})`));
+  lines.push('');
+
+  // Group rules by field, preserving the order in which each field first appears.
+  const byField = new Map<string, RuleDescription[]>();
+  for (const rule of rules) {
+    const list = byField.get(rule.field) ?? [];
+    list.push(rule);
+    byField.set(rule.field, list);
+  }
+
+  const width = Math.max(...[...byField.keys()].map((field) => field.length));
+  for (const [field, fieldRules] of byField) {
+    const phrases = fieldRules.map(formatConstraint);
+    // A required field is surfaced as an explicit "required" constraint at the front.
+    if (fieldRules.some((rule) => rule.required)) {
+      phrases.unshift(chalk.italic('required'));
+    }
+    // Dedupe identical phrases (some fields are constrained by several rules that overlap).
+    const constraints = [...new Set(phrases)].join('; ');
+    lines.push(`  ${chalk.bold(field.padEnd(width))}  ${constraints}`);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Render a single rule's constraint as a human-readable phrase.
+ *
+ * @param rule the rule description to render
+ * @returns a phrase such as `must be one of: es2022, es2023` or `not allowed`
+ */
+export function formatConstraint(rule: RuleDescription): string {
+  const { type, values } = rule;
+
+  // No hints means the matcher accepts anything (e.g. Match.ANY).
+  if (values === undefined) {
+    return type === RuleType.PASS ? chalk.italic('any value') : 'must not be set to the matched value';
+  }
+
+  // Only null/undefined hints means the option must be absent (e.g. Match.MISSING).
+  if (values.length > 0 && values.every((value) => value == null)) {
+    return chalk.italic('not allowed');
+  }
+
+  const formatted = values.map(formatRuleValue);
+  if (type === RuleType.FAIL) {
+    return formatted.length > 1 ? `must not be one of: ${formatted.join(', ')}` : `must not be ${formatted[0]}`;
+  }
+  return formatted.length > 1 ? `must be one of: ${formatted.join(', ')}` : `must be ${formatted[0]}`;
+}
+
+/**
+ * Render a single hinted value as a highlighted code literal. Strings are shown
+ * verbatim (as a user writes them in tsconfig.json), everything else is JSON-encoded.
+ *
+ * @param value the hinted value to render
+ * @returns the value as a (possibly colorized) code literal
+ */
+export function formatRuleValue(value: any): string {
+  const literal = typeof value === 'string' ? value : JSON.stringify(value);
+  return chalk.cyan(literal);
+}

--- a/src/tsconfig/tsconfig-validator.ts
+++ b/src/tsconfig/tsconfig-validator.ts
@@ -1,8 +1,12 @@
+import * as path from 'node:path';
+import * as ts from 'typescript';
 import { TypeScriptConfig, TypeScriptConfigValidationRuleSet } from '.';
+import { convertForJson } from './compiler-options';
+import { JsiiError } from '../utils';
 import generated from './rulesets/generated.public';
 import minimal from './rulesets/minimal.public';
 import strict from './rulesets/strict.public';
-import { Match, ObjectValidator, RuleSet, RuleType } from './validator';
+import { Match, ObjectValidator, RuleDescription, RuleSet, RuleType, ValidationError, Violation } from './validator';
 
 const RuleSets: {
   [name in TypeScriptConfigValidationRuleSet]: RuleSet;
@@ -47,5 +51,89 @@ export class TypeScriptConfigValidator {
    */
   public validate(tsconfig: TypeScriptConfig) {
     this.validator.validate(tsconfig);
+  }
+}
+
+/**
+ * Returns the `compilerOptions` rule set that backs the given validation setting.
+ *
+ * These are the substantive, set-specific rules (the top-level rules such as
+ * `files`/`include`/`exclude` are identical across all sets). The `off` rule set
+ * is empty, as it disables validation.
+ *
+ * @param ruleSet the validation setting to look up
+ * @returns the `RuleSet` applied to `compilerOptions`
+ */
+export function getCompilerOptionsRuleSet(ruleSet: TypeScriptConfigValidationRuleSet): RuleSet {
+  return RuleSets[ruleSet];
+}
+
+/**
+ * Produces a human-readable description of every `compilerOptions` rule in a rule set.
+ *
+ * @param ruleSet the validation setting to describe
+ * @returns a description for every rule in the set
+ */
+export function describeRuleSet(ruleSet: TypeScriptConfigValidationRuleSet): RuleDescription[] {
+  return getCompilerOptionsRuleSet(ruleSet).describe();
+}
+
+/**
+ * Reads and parses a `tsconfig.json` file from disk into the format expected by
+ * the validator. This resolves `extends` and normalizes the options the same way
+ * the compiler does, so validation behaves identically to a real compilation.
+ *
+ * @param configPath the path to the tsconfig file to read
+ * @throws {@link JsiiError} if the file cannot be read or parsed
+ * @returns the parsed TypeScript configuration
+ */
+export function readTypeScriptConfig(configPath: string): TypeScriptConfig {
+  const absolutePath = path.resolve(configPath);
+  const { config, error } = ts.readConfigFile(absolutePath, ts.sys.readFile);
+  if (error) {
+    throw new JsiiError(
+      `Failed to read tsconfig at "${configPath}": ${ts.flattenDiagnosticMessageText(error.messageText, '\n')}`,
+    );
+  }
+
+  const basePath = path.dirname(absolutePath);
+  const extended = ts.parseJsonConfigFileContent(config, ts.sys, basePath);
+  // the tsconfig parser adds this in, but it is not an expected compilerOption
+  delete extended.options.configFilePath;
+
+  return {
+    compilerOptions: extended.options,
+    watchOptions: extended.watchOptions,
+    include: extended.fileNames,
+  };
+}
+
+/**
+ * Reads a `tsconfig.json` file from disk and validates its `compilerOptions`
+ * against the given rule set, without running a compilation.
+ *
+ * @param configPath the path to the tsconfig file to validate
+ * @param ruleSet the rule set to validate against
+ * @throws {@link JsiiError} if the file cannot be read or parsed
+ * @returns the list of rule violations (empty if the config is valid)
+ */
+export function validateTypeScriptConfigFile(
+  configPath: string,
+  ruleSet: TypeScriptConfigValidationRuleSet,
+): Violation[] {
+  const config = readTypeScriptConfig(configPath);
+  const validator = new TypeScriptConfigValidator(ruleSet);
+  try {
+    validator.validate({
+      ...config,
+      // convert the internal format to the user format which is what the validator operates on
+      compilerOptions: convertForJson(config.compilerOptions),
+    });
+    return [];
+  } catch (error: unknown) {
+    if (error instanceof ValidationError) {
+      return error.violations;
+    }
+    throw error;
   }
 }

--- a/src/tsconfig/validator.ts
+++ b/src/tsconfig/validator.ts
@@ -47,6 +47,41 @@ interface Rule {
   matcher: Matcher;
 }
 
+/**
+ * A human-readable description of a single rule.
+ * Intended for displaying a rule set to a user, e.g. via the CLI.
+ */
+export interface RuleDescription {
+  /**
+   * The field (compilerOption) the rule applies to.
+   */
+  readonly field: string;
+
+  /**
+   * Whether the value must match (`PASS`) or must not match (`FAIL`) the constraint.
+   */
+  readonly type: RuleType;
+
+  /**
+   * Whether the field is required to be present for the rule to pass.
+   */
+  readonly required: boolean;
+
+  /**
+   * The values the matcher offered as hints.
+   * For `PASS` rules these are allowed values, for `FAIL` rules these are disallowed values.
+   * `undefined` when the matcher did not offer any hints (e.g. any value is accepted).
+   */
+  readonly values?: any[];
+}
+
+/**
+ * A sentinel value used to probe matchers for hints.
+ * It is intentionally not `null`/`undefined` so that `Match.optional` delegates
+ * to its inner matcher (which is where the hints are recorded).
+ */
+const DESCRIBE_PROBE = Symbol('jsii.tsconfig.describe.probe');
+
 export class RuleSet {
   private _rules: Array<Rule> = [];
   public get rules(): Array<Rule> {
@@ -169,6 +204,42 @@ export class RuleSet {
     }
 
     return fieldHints;
+  }
+
+  /**
+   * Produces a human-readable description of every rule in the set.
+   *
+   * This is derived directly from the rules (it does not duplicate them), so it
+   * stays in sync as rules are added or changed. It is primarily intended for
+   * surfacing a rule set to a user, e.g. via the CLI.
+   *
+   * @returns A description for every rule, in the order the rules were added.
+   */
+  public describe(): RuleDescription[] {
+    return this._rules.map((rule) => {
+      // Probe the matcher for the values it considers relevant (hints).
+      const values: any[] = [];
+      let hinted = false;
+      rule.matcher(DESCRIBE_PROBE, {
+        hints: (allowed) => {
+          hinted = true;
+          if (allowed) {
+            values.push(...allowed);
+          }
+        },
+      });
+
+      // A field is required if the rule is not satisfied when the value is absent.
+      const passesWhenAbsent = rule.matcher(undefined);
+      const required = rule.type === RuleType.PASS ? !passesWhenAbsent : passesWhenAbsent;
+
+      return {
+        field: rule.field,
+        type: rule.type,
+        required,
+        values: hinted ? values : undefined,
+      };
+    });
   }
 }
 

--- a/test/tsconfig/describe.test.ts
+++ b/test/tsconfig/describe.test.ts
@@ -1,0 +1,175 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { TypeScriptConfigValidationRuleSet } from '../../src/tsconfig';
+import {
+  describeRuleSet,
+  getCompilerOptionsRuleSet,
+  readTypeScriptConfig,
+  validateTypeScriptConfigFile,
+} from '../../src/tsconfig/tsconfig-validator';
+import { Match, RuleSet, RuleType } from '../../src/tsconfig/validator';
+import { JsiiError } from '../../src/utils';
+
+describe('RuleSet.describe()', () => {
+  test('describes a required "must be one of" PASS rule with hinted values', () => {
+    const ruleSet = new RuleSet();
+    ruleSet.shouldPass('target', Match.oneOf('es2022', 'es2023', 'esnext'));
+
+    const [rule] = ruleSet.describe();
+    expect(rule).toEqual({
+      field: 'target',
+      type: RuleType.PASS,
+      required: true,
+      values: ['es2022', 'es2023', 'esnext'],
+    });
+  });
+
+  test('describes an optional PASS rule as not required', () => {
+    const ruleSet = new RuleSet();
+    ruleSet.shouldPass('stripInternal', Match.optional(Match.FALSE));
+
+    const [rule] = ruleSet.describe();
+    expect(rule.required).toBe(false);
+    expect(rule.type).toBe(RuleType.PASS);
+    expect(rule.values).toEqual([false]);
+  });
+
+  test('describes a FAIL rule with its disallowed values', () => {
+    const ruleSet = new RuleSet();
+    ruleSet.shouldFail('noEmit', Match.TRUE);
+
+    const [rule] = ruleSet.describe();
+    expect(rule.type).toBe(RuleType.FAIL);
+    expect(rule.required).toBe(false);
+    expect(rule.values).toEqual([true]);
+  });
+
+  test('describes a MISSING rule (values are null/undefined)', () => {
+    const ruleSet = new RuleSet();
+    ruleSet.shouldPass('prepend', Match.MISSING);
+
+    const [rule] = ruleSet.describe();
+    expect(rule.required).toBe(false);
+    expect(rule.values).toEqual([undefined, null]);
+  });
+
+  test('describes a Match.ANY rule as having no hinted values', () => {
+    const ruleSet = new RuleSet();
+    ruleSet.shouldPass('incremental', Match.ANY);
+
+    const [rule] = ruleSet.describe();
+    expect(rule.values).toBeUndefined();
+  });
+
+  test('preserves rule order', () => {
+    const ruleSet = new RuleSet();
+    ruleSet.shouldPass('a', Match.ANY);
+    ruleSet.shouldFail('b', Match.TRUE);
+
+    expect(ruleSet.describe().map((r) => r.field)).toEqual(['a', 'b']);
+  });
+});
+
+describe('describeRuleSet()', () => {
+  test('strict requires a valid "target"', () => {
+    const target = describeRuleSet(TypeScriptConfigValidationRuleSet.STRICT).find(
+      (rule) => rule.field === 'target' && rule.type === RuleType.PASS,
+    );
+
+    expect(target).toBeDefined();
+    expect(target?.required).toBe(true);
+    expect(target?.values).toEqual(expect.arrayContaining(['es2022', 'es2023', 'esnext']));
+  });
+
+  test('"off" rule set has no compilerOptions rules', () => {
+    expect(describeRuleSet(TypeScriptConfigValidationRuleSet.NONE)).toEqual([]);
+  });
+
+  test('strict rejects unknown options, minimal does not', () => {
+    expect(getCompilerOptionsRuleSet(TypeScriptConfigValidationRuleSet.STRICT).options.unexpectedFields).toBe(
+      RuleType.FAIL,
+    );
+    expect(getCompilerOptionsRuleSet(TypeScriptConfigValidationRuleSet.MINIMAL).options.unexpectedFields).toBe(
+      RuleType.PASS,
+    );
+  });
+});
+
+describe('validateTypeScriptConfigFile()', () => {
+  let workdir: string;
+
+  beforeEach(() => {
+    workdir = mkdtempSync(join(tmpdir(), 'jsii-validate-tsconfig-'));
+  });
+
+  afterEach(() => {
+    rmSync(workdir, { recursive: true, force: true });
+  });
+
+  function writeConfig(contents: object): string {
+    const configPath = join(workdir, 'tsconfig.json');
+    writeFileSync(configPath, JSON.stringify(contents), 'utf-8');
+    return configPath;
+  }
+
+  test('returns no violations for a config that satisfies the strict rule set', () => {
+    const configPath = writeConfig({
+      compilerOptions: {
+        strict: true,
+        target: 'es2023',
+        lib: ['es2023'],
+        module: 'node16',
+        esModuleInterop: true,
+        skipLibCheck: true,
+        noEmitOnError: true,
+        declaration: true,
+      },
+    });
+
+    expect(validateTypeScriptConfigFile(configPath, TypeScriptConfigValidationRuleSet.STRICT)).toEqual([]);
+  });
+
+  test('returns violations for a config that breaks the strict rule set', () => {
+    const configPath = writeConfig({
+      compilerOptions: {
+        strict: false,
+        target: 'es2023',
+        lib: ['es2023'],
+        module: 'node16',
+        esModuleInterop: true,
+        skipLibCheck: true,
+        noEmitOnError: true,
+        declaration: true,
+      },
+    });
+
+    const violations = validateTypeScriptConfigFile(configPath, TypeScriptConfigValidationRuleSet.STRICT);
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations.some((v) => v.field === 'strict')).toBe(true);
+  });
+
+  test('flags a recognized option that is not on the strict allowlist', () => {
+    const configPath = writeConfig({
+      compilerOptions: {
+        strict: true,
+        target: 'es2023',
+        lib: ['es2023'],
+        module: 'node16',
+        esModuleInterop: true,
+        skipLibCheck: true,
+        noEmitOnError: true,
+        declaration: true,
+        // a valid TypeScript option, but not part of the jsii strict allowlist
+        removeComments: true,
+      },
+    });
+
+    const violations = validateTypeScriptConfigFile(configPath, TypeScriptConfigValidationRuleSet.STRICT);
+    expect(violations.some((v) => v.field === 'removeComments')).toBe(true);
+  });
+
+  test('throws a JsiiError when the file does not exist', () => {
+    expect(() => readTypeScriptConfig(join(workdir, 'does-not-exist.json'))).toThrow(JsiiError);
+  });
+});

--- a/test/tsconfig/rule-set-format.test.ts
+++ b/test/tsconfig/rule-set-format.test.ts
@@ -1,0 +1,107 @@
+import chalk from 'chalk';
+import { TypeScriptConfigValidationRuleSet } from '../../src/tsconfig';
+import {
+  formatConstraint,
+  formatRuleSet,
+  formatRuleValue,
+  RULE_SET_DESCRIPTIONS,
+} from '../../src/tsconfig/rule-set-format';
+import { RuleDescription, RuleType } from '../../src/tsconfig/validator';
+
+// Render deterministically (no ANSI escape codes) so assertions match plain text.
+let previousChalkLevel: chalk.Level;
+beforeAll(() => {
+  previousChalkLevel = chalk.level;
+  chalk.level = 0;
+});
+afterAll(() => {
+  chalk.level = previousChalkLevel;
+});
+
+describe('formatRuleValue()', () => {
+  test('renders strings verbatim', () => {
+    expect(formatRuleValue('es2022')).toBe('es2022');
+  });
+
+  test('JSON-encodes non-string values', () => {
+    expect(formatRuleValue(true)).toBe('true');
+    expect(formatRuleValue(false)).toBe('false');
+    expect(formatRuleValue(['es2022'])).toBe('["es2022"]');
+  });
+});
+
+describe('formatConstraint()', () => {
+  function rule(partial: Partial<RuleDescription>): RuleDescription {
+    return { field: 'x', type: RuleType.PASS, required: false, ...partial };
+  }
+
+  test('PASS with a single value', () => {
+    expect(formatConstraint(rule({ type: RuleType.PASS, values: [true] }))).toBe('must be true');
+  });
+
+  test('PASS with multiple values', () => {
+    expect(formatConstraint(rule({ type: RuleType.PASS, values: ['es2022', 'es2023'] }))).toBe(
+      'must be one of: es2022, es2023',
+    );
+  });
+
+  test('FAIL with a single value', () => {
+    expect(formatConstraint(rule({ type: RuleType.FAIL, values: [true] }))).toBe('must not be true');
+  });
+
+  test('FAIL with multiple values', () => {
+    expect(formatConstraint(rule({ type: RuleType.FAIL, values: ['amd', 'umd'] }))).toBe(
+      'must not be one of: amd, umd',
+    );
+  });
+
+  test('PASS without hinted values allows anything', () => {
+    expect(formatConstraint(rule({ type: RuleType.PASS, values: undefined }))).toBe('any value');
+  });
+
+  test('null/undefined hints mean the option is not allowed', () => {
+    expect(formatConstraint(rule({ type: RuleType.PASS, values: [undefined, null] }))).toBe('not allowed');
+  });
+});
+
+describe('formatRuleSet()', () => {
+  test('includes the heading and description', () => {
+    const out = formatRuleSet(TypeScriptConfigValidationRuleSet.STRICT);
+    expect(out).toContain('Rule set: strict');
+    expect(out).toContain(RULE_SET_DESCRIPTIONS.strict);
+  });
+
+  test('strict rejects unknown options and surfaces required + allowed values', () => {
+    const out = formatRuleSet(TypeScriptConfigValidationRuleSet.STRICT);
+    expect(out).toContain('other options: rejected');
+    expect(out).toMatch(/target\s+required; must be one of: es2022, es2023, esnext; must not be es5/);
+  });
+
+  test('dedupes identical overlapping constraints', () => {
+    const out = formatRuleSet(TypeScriptConfigValidationRuleSet.STRICT);
+    // alwaysStrict is constrained by two rules that both resolve to "must be true"
+    expect(out).not.toContain('must be true; must be true');
+    expect(out).toMatch(/alwaysStrict\s+must be true$/m);
+  });
+
+  test('minimal allows unknown options', () => {
+    const out = formatRuleSet(TypeScriptConfigValidationRuleSet.MINIMAL);
+    expect(out).toContain('other options: allowed');
+    expect(out).toMatch(/noEmit\s+must not be true/);
+  });
+
+  test('off reports that validation is disabled', () => {
+    const out = formatRuleSet(TypeScriptConfigValidationRuleSet.NONE);
+    expect(out).toContain('Rule set: off');
+    expect(out).toContain('No rules.');
+  });
+});
+
+describe('RULE_SET_DESCRIPTIONS', () => {
+  test('has a description for every rule set', () => {
+    for (const ruleSet of Object.values(TypeScriptConfigValidationRuleSet)) {
+      expect(typeof RULE_SET_DESCRIPTIONS[ruleSet]).toBe('string');
+      expect(RULE_SET_DESCRIPTIONS[ruleSet].length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
When a project supplies its own `tsconfig.json`, `jsii` validates the `compilerOptions` against a rule set (`strict` by default). Until now the only way to discover what a rule set enforces, or to find out whether a given config passes, was to run a full compilation and read the resulting diagnostics. That is a slow and indirect feedback loop, and it offers no way to see the rules themselves.

This adds two standalone commands that expose the existing validation machinery directly. `jsii rules [RULE_SET]` prints the rules for a rule set (or for all of them when no set is given), listing per `compilerOptions` field whether it must be present and which values are allowed or disallowed, so authors can understand the constraints without trial and error. `jsii validate-tsconfig [TSCONFIG]` validates a configuration file against a rule set and exits non-zero on failure, which makes it usable as a CI or pre-commit check; it defaults to `./tsconfig.json` and accepts `--rule-set` (alias `-R`) to pick the set.

Both commands reuse the same parsing and rule sets the compiler already uses, and `validate-tsconfig` emits the same `JSII4000`/`JSII4009` diagnostics as a real compilation, so the standalone behavior matches what happens during a build. To keep the rule descriptions in sync with the rules rather than duplicating them, the listing is derived from the matchers themselves via a new `RuleSet.describe()`.

The README gains a section documenting both commands, and tests cover the rule description extraction and file-based validation.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
