### PR TITLE
feat: Add support for Ruby

### DIFF
--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -2811,6 +2811,7 @@ export class Assembler implements Emitter {
     const javaPackages: Record<string, string[]> = {};
     const pythonModules: Record<string, string[]> = {};
     const goPackages: Record<string, string[]> = {};
+    const rubyModules: Record<string, string[]> = {};
 
     for (const submodule of this._submodules.values()) {
       const targets = submodule.targets as AssemblyTargets | undefined;
@@ -2827,12 +2828,16 @@ export class Assembler implements Emitter {
       if (targets?.go?.packageName) {
         accumList(goPackages, targets.go.packageName, submodule.fqn);
       }
+      if (targets?.ruby?.module) {
+        accumList(rubyModules, targets.ruby.module, submodule.fqn);
+      }
     }
 
     maybeError('dotnet', dotNetnamespaces);
     maybeError('java', javaPackages);
     maybeError('python', pythonModules);
     maybeError('go', goPackages);
+    maybeError('ruby', rubyModules);
 
     function accumList(set: Record<string, string[]>, key: string, value: string) {
       if (!set[key]) {

--- a/src/project-info.ts
+++ b/src/project-info.ts
@@ -56,6 +56,11 @@ export type AssemblyTargets = spec.PackageJson['jsii']['targets'] & {
     moduleName: string;
     packageName: string;
   };
+  ruby?: {
+    gem?: string;
+    module?: string;
+    acronyms?: string[];
+  };
   [otherLanguage: string]: unknown;
 };
 
@@ -316,6 +321,7 @@ export function validateTargets(targets: AssemblyTargets | undefined): AssemblyT
     python: ['module', 'distName', 'classifiers'],
     dotnet: ['namespace', 'packageId', 'iconUrl', 'versionSuffix'],
     go: ['moduleName', 'packageName', 'versionSuffix'],
+    ruby: ['gem', 'module', 'acronyms'],
   };
 
   for (const [language, config] of Object.entries(targets)) {
@@ -379,6 +385,17 @@ export function validateTargets(targets: AssemblyTargets | undefined): AssemblyT
   ) {
     if (!targets.python.module.split('.').every(isIdentifier)) {
       throw new JsiiError(`jsii.targets.python.module contains non-identifier characters: ${targets.python.module}`);
+    }
+  }
+
+  if (
+    targets.ruby &&
+    typeof targets.ruby === 'object' &&
+    'module' in targets.ruby &&
+    typeof targets.ruby.module === 'string'
+  ) {
+    if (!targets.ruby.module.split('::').every(isIdentifier)) {
+      throw new JsiiError(`jsii.targets.ruby.module contains non-identifier characters: ${targets.ruby.module}`);
     }
   }
 

--- a/test/project-info.test.ts
+++ b/test/project-info.test.ts
@@ -295,6 +295,59 @@ describe('loadProjectInfo', () => {
       });
     });
 
+    test('valid Ruby target configuration is loaded', () => {
+      return _withTestProject(
+        (projectRoot) => {
+          const { projectInfo } = loadProjectInfo(projectRoot);
+          expect(projectInfo.targets.ruby).toEqual({
+            gem: 'my-gem',
+            module: 'MyModule',
+            acronyms: ['AWS'],
+          });
+        },
+        (info) => {
+          info.jsii.targets.ruby = {
+            gem: 'my-gem',
+            module: 'MyModule',
+            acronyms: ['AWS'],
+          };
+        },
+      );
+    });
+
+    test('valid nested Ruby module namespace is loaded', () => {
+      return _withTestProject(
+        (projectRoot) => {
+          const { projectInfo } = loadProjectInfo(projectRoot);
+          expect(projectInfo.targets.ruby?.module).toEqual('My::Nested::Module');
+        },
+        (info) => {
+          info.jsii.targets.ruby = {
+            gem: 'my-gem',
+            module: 'My::Nested::Module',
+          };
+        },
+      );
+    });
+
+    test('invalid Ruby target key is rejected', () => {
+      expectProjectLoadError(/Unknown key in jsii.targets.ruby: invalid/, (proj) => {
+        proj.jsii.targets.ruby = {
+          gem: 'my-gem',
+          invalid: 'value',
+        } as any;
+      });
+    });
+
+    test('invalid Ruby module name is rejected', () => {
+      expectProjectLoadError(/jsii.targets.ruby.module contains non-identifier characters/, (proj) => {
+        proj.jsii.targets.ruby = {
+          gem: 'my-gem',
+          module: 'My-Module',
+        };
+      });
+    });
+
     function expectProjectLoadError(error: RegExp, gremlin: Parameters<typeof _withTestProject>[1]) {
       _withTestProject((root) => expect(() => loadProjectInfo(root)).toThrow(error), gremlin);
     }


### PR DESCRIPTION
Add Ruby target support in jsii-compiler — recognise and validate a `ruby` block under `jsii.targets` in `package.json`, exactly as for `java`/`python`/`dotnet`/`go`. Strictly additive; the `.jsii` assembly format is unchanged. Resolves #2667.

Part of the Ruby language support effort:

- RFC (umbrella tracking): https://github.com/aws/aws-cdk-rfcs/issues/935
- jsii tracking issue: https://github.com/aws/jsii/issues/5129
- Downstream runtime + `jsii-pacmak` Ruby target: https://github.com/aws/jsii/pull/5178

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
