### PR TITLE
chore: pass github.ref_name through env in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,12 +38,15 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
       - name: Prepare Release
-        run: yarn release ${{ github.ref_name }}
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: yarn release "$RELEASE_TAG"
       - name: Determine Target
         id: publish-target
         env:
+          RELEASE_TAG: ${{ github.ref_name }}
           GITHUB_TOKEN: ${{ github.token }}
-        run: yarn ts-node projenrc/publish-target.ts ${{ github.ref_name }}
+        run: yarn ts-node projenrc/publish-target.ts "$RELEASE_TAG"
       - name: Federate to AWS
         if: fromJSON(steps.publish-target.outputs.github-release)
         uses: aws-actions/configure-aws-credentials@v6
@@ -97,8 +100,9 @@ jobs:
         id: release-exists
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |-
-          if gh release view ${{ github.ref_name }} --repo=${{ github.repository }} &>/dev/null
+          if gh release view "$RELEASE_TAG" --repo=${{ github.repository }} &>/dev/null
           then
           echo "result=true" >> $GITHUB_OUTPUT
           else
@@ -108,16 +112,19 @@ jobs:
         if: "!fromJSON(steps.release-exists.outputs.result) && fromJSON(needs.build.outputs.prerelease)"
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create ${{ github.ref_name }} --repo=${{ github.repository }} --generate-notes --title=${{ github.ref_name }} --verify-tag --prerelease --latest=${{ needs.build.outputs.latest }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: gh release create "$RELEASE_TAG" --repo=${{ github.repository }} --generate-notes --title="$RELEASE_TAG" --verify-tag --prerelease --latest=${{ needs.build.outputs.latest }}
       - name: Create Release
         if: "!fromJSON(steps.release-exists.outputs.result) && !fromJSON(needs.build.outputs.prerelease)"
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create ${{ github.ref_name }} --repo=${{ github.repository }} --generate-notes --title=${{ github.ref_name }} --verify-tag --latest=${{ needs.build.outputs.latest }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: gh release create "$RELEASE_TAG" --repo=${{ github.repository }} --generate-notes --title="$RELEASE_TAG" --verify-tag --latest=${{ needs.build.outputs.latest }}
       - name: Attach assets
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload ${{ github.ref_name }} --repo=${{ github.repository }} --clobber ${{ github.workspace }}/**/*
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: gh release upload "$RELEASE_TAG" --repo=${{ github.repository }} --clobber ${{ github.workspace }}/**/*
   release-npm-package:
     name: Release to registry.npmjs.org
     needs: build
@@ -157,4 +164,6 @@ jobs:
         run: npm publish ${{ github.workspace }}/js/jsii-*.tgz --access=public --provenance --tag=${{ needs.build.outputs.dist-tag }}
       - name: Tag "latest"
         if: fromJSON(needs.build.outputs.latest)
-        run: npm dist-tag add jsii@${{ github.ref_name }} latest
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: npm dist-tag add "jsii@$RELEASE_TAG" latest

--- a/projenrc/release.ts
+++ b/projenrc/release.ts
@@ -70,13 +70,17 @@ export class ReleaseWorkflow {
         ...workflowSetup(this.project),
         {
           name: 'Prepare Release',
-          run: 'yarn release ${{ github.ref_name }}',
+          env: {
+            RELEASE_TAG: '${{ github.ref_name }}',
+          },
+          run: 'yarn release "$RELEASE_TAG"',
         },
         {
           name: 'Determine Target',
           id: publishTarget,
-          run: 'yarn ts-node projenrc/publish-target.ts ${{ github.ref_name }}',
+          run: 'yarn ts-node projenrc/publish-target.ts "$RELEASE_TAG"',
           env: {
+            RELEASE_TAG: '${{ github.ref_name }}',
             // A GitHub token is required to list GitHub Releases, so we can tell if the `latest` dist-tag is needed.
             GITHUB_TOKEN: '${{ github.token }}',
           },
@@ -154,7 +158,7 @@ export class ReleaseWorkflow {
           id: 'release-exists',
           name: 'Verify if release exists',
           run: [
-            'if gh release view ${{ github.ref_name }} --repo=${{ github.repository }} &>/dev/null',
+            'if gh release view "$RELEASE_TAG" --repo=${{ github.repository }} &>/dev/null',
             'then',
             'echo "result=true" >> $GITHUB_OUTPUT',
             'else',
@@ -163,49 +167,53 @@ export class ReleaseWorkflow {
           ].join('\n'),
           env: {
             GH_TOKEN: '${{ github.token }}',
+            RELEASE_TAG: '${{ github.ref_name }}',
           },
         },
         {
           name: 'Create PreRelease',
           if: `!fromJSON(steps.release-exists.outputs.result) && fromJSON(needs.build.outputs.${PublishTargetOutput.IS_PRERELEASE})`,
           run: [
-            'gh release create ${{ github.ref_name }}',
+            'gh release create "$RELEASE_TAG"',
             '--repo=${{ github.repository }}',
             '--generate-notes',
-            '--title=${{ github.ref_name }}',
+            '--title="$RELEASE_TAG"',
             '--verify-tag',
             '--prerelease',
             `--latest=\${{ needs.build.outputs.${PublishTargetOutput.IS_LATEST} }}`,
           ].join(' '),
           env: {
             GH_TOKEN: '${{ github.token }}',
+            RELEASE_TAG: '${{ github.ref_name }}',
           },
         },
         {
           name: 'Create Release',
           if: `!fromJSON(steps.release-exists.outputs.result) && !fromJSON(needs.build.outputs.${PublishTargetOutput.IS_PRERELEASE})`,
           run: [
-            'gh release create ${{ github.ref_name }}',
+            'gh release create "$RELEASE_TAG"',
             '--repo=${{ github.repository }}',
             '--generate-notes',
-            '--title=${{ github.ref_name }}',
+            '--title="$RELEASE_TAG"',
             '--verify-tag',
             `--latest=\${{ needs.build.outputs.${PublishTargetOutput.IS_LATEST} }}`,
           ].join(' '),
           env: {
             GH_TOKEN: '${{ github.token }}',
+            RELEASE_TAG: '${{ github.ref_name }}',
           },
         },
         {
           name: 'Attach assets',
           run: [
-            'gh release upload ${{ github.ref_name }}',
+            'gh release upload "$RELEASE_TAG"',
             '--repo=${{ github.repository }}',
             '--clobber',
             '${{ github.workspace }}/**/*',
           ].join(' '),
           env: {
             GH_TOKEN: '${{ github.token }}',
+            RELEASE_TAG: '${{ github.ref_name }}',
           },
         },
       ],
@@ -260,7 +268,10 @@ export class ReleaseWorkflow {
         {
           name: 'Tag "latest"',
           if: `fromJSON(needs.build.outputs.${PublishTargetOutput.IS_LATEST})`,
-          run: 'npm dist-tag add jsii@${{ github.ref_name }} latest',
+          env: {
+            RELEASE_TAG: '${{ github.ref_name }}',
+          },
+          run: 'npm dist-tag add "jsii@$RELEASE_TAG" latest',
         },
       ],
     });


### PR DESCRIPTION
## Summary

The release workflow interpolates `${{ github.ref_name }}` directly into `run:` shell blocks. Tag names are user-controlled input that can contain shell metacharacters, and GitHub Actions performs textual substitution before the shell parses the script, so the interpolation is exploitable as command injection.

This PR routes the tag name through an environment variable. Bash expands `$RELEASE_TAG` at runtime without re-parsing the value for metacharacters, defeating the injection.

`run-name` and `role-session-name` still reference `github.ref_name`. Neither is an execution sink: `run-name` is display-only, and IAM session names are validated to `[\w+=,.@-]`.

Pattern from GitHub's hardening guidance: <https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#good-practices-for-mitigating-script-injection-attacks>
