### PR TITLE
feat(cli): read validate-tsconfig defaults from package.json

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import '@jsii/check-node/run';
 
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as util from 'node:util';
 import chalk from 'chalk';
@@ -206,24 +207,31 @@ enum OPTION_GROUP {
           .positional('TSCONFIG', {
             type: 'string',
             desc: 'The TypeScript configuration file to validate',
-            default: 'tsconfig.json',
+            defaultDescription: 'jsii.tsconfig from package.json, or tsconfig.json',
             normalize: true,
           })
           .option('rule-set', {
             group: OPTION_GROUP.TS,
             alias: 'R',
             ...choiceWithDesc(RULE_SET_DESCRIPTIONS, 'The rule set to validate the configuration file against.'),
-            default: TypeScriptConfigValidationRuleSet.STRICT,
+            defaultDescription: TypeScriptConfigValidationRuleSet.STRICT,
           }),
       (argv) => {
         try {
           const verbosity = typeof argv.verbose === 'number' ? argv.verbose : 0;
           _configureLog4js(verbosity);
 
-          const configPath = path.resolve(process.cwd(), argv.TSCONFIG);
+          // Read package.json config only when needed (tsconfig or rule-set not explicitly provided)
+          const jsiiConfig =
+            argv.TSCONFIG == null || argv['rule-set'] == null ? _readJsiiConfig(process.cwd()) : undefined;
+
+          const tsconfigFile = argv.TSCONFIG ?? jsiiConfig?.tsconfig ?? 'tsconfig.json';
+          const configPath = path.resolve(process.cwd(), tsconfigFile);
           const projectRoot = path.dirname(configPath);
           const configName = path.relative(projectRoot, configPath);
-          const ruleSet = argv['rule-set'] as TypeScriptConfigValidationRuleSet;
+          const ruleSet = (argv['rule-set'] ??
+            jsiiConfig?.validateTsconfig ??
+            TypeScriptConfigValidationRuleSet.STRICT) as TypeScriptConfigValidationRuleSet;
 
           // Validation is disabled for the "off" rule set; mirror the compiler behavior.
           if (ruleSet === TypeScriptConfigValidationRuleSet.NONE) {
@@ -336,5 +344,14 @@ function _configureLog4js(verbosity: number) {
       default:
         return 'ALL';
     }
+  }
+}
+
+function _readJsiiConfig(dir: string): { tsconfig?: string; validateTsconfig?: string } | undefined {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf-8'));
+    return pkg.jsii;
+  } catch {
+    return undefined;
   }
 }

--- a/test/tsconfig/validate-tsconfig-cli.test.ts
+++ b/test/tsconfig/validate-tsconfig-cli.test.ts
@@ -1,7 +1,7 @@
+import { spawnSync } from 'node:child_process';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { spawnSync } from 'node:child_process';
 
 const MAIN = join(__dirname, '..', '..', 'src', 'main.ts');
 

--- a/test/tsconfig/validate-tsconfig-cli.test.ts
+++ b/test/tsconfig/validate-tsconfig-cli.test.ts
@@ -1,0 +1,90 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const MAIN = join(__dirname, '..', '..', 'src', 'main.ts');
+
+describe('validate-tsconfig CLI defaults', () => {
+  let workdir: string;
+
+  beforeEach(() => {
+    workdir = mkdtempSync(join(tmpdir(), 'jsii-validate-tsconfig-cli-'));
+  });
+
+  afterEach(() => {
+    rmSync(workdir, { recursive: true, force: true });
+  });
+
+  function run(...args: string[]) {
+    return spawnSync('npx', ['tsx', MAIN, 'validate-tsconfig', ...args], {
+      cwd: workdir,
+      encoding: 'utf-8',
+    });
+  }
+
+  test('reads tsconfig path from package.json jsii.tsconfig', () => {
+    writeFileSync(join(workdir, 'package.json'), JSON.stringify({ jsii: { tsconfig: 'custom.json' } }));
+
+    const result = run();
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('custom.json');
+  });
+
+  test('reads rule-set from package.json jsii.validateTsconfig', () => {
+    writeFileSync(join(workdir, 'package.json'), JSON.stringify({ jsii: { validateTsconfig: 'off' } }));
+    writeFileSync(join(workdir, 'tsconfig.json'), JSON.stringify({ compilerOptions: {} }));
+
+    const result = run();
+    expect(result.stdout).toMatch(/disabled/i);
+    expect(result.status).toBe(0);
+  });
+
+  test('explicit CLI args override package.json', () => {
+    writeFileSync(
+      join(workdir, 'package.json'),
+      JSON.stringify({ jsii: { tsconfig: 'ignored.json', validateTsconfig: 'off' } }),
+    );
+    writeFileSync(
+      join(workdir, 'tsconfig.json'),
+      JSON.stringify({
+        compilerOptions: {
+          strict: true,
+          target: 'es2023',
+          lib: ['es2023'],
+          module: 'node16',
+          esModuleInterop: true,
+          skipLibCheck: true,
+          noEmitOnError: true,
+          declaration: true,
+        },
+      }),
+    );
+
+    const result = run('tsconfig.json', '--rule-set', 'strict');
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('valid');
+  });
+
+  test('falls back to tsconfig.json when no package.json exists', () => {
+    writeFileSync(
+      join(workdir, 'tsconfig.json'),
+      JSON.stringify({
+        compilerOptions: {
+          strict: true,
+          target: 'es2023',
+          lib: ['es2023'],
+          module: 'node16',
+          esModuleInterop: true,
+          skipLibCheck: true,
+          noEmitOnError: true,
+          declaration: true,
+        },
+      }),
+    );
+
+    const result = run();
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('valid');
+  });
+});


### PR DESCRIPTION
The recently introduced `validate-tsconfig` command previously didn't read a jsii config from `package.json`. This meant users who already configured `jsii.tsconfig` or `jsii.validateTsconfig` had to repeat themselves on the CLI.

Now, when either argument is omitted, the command reads `package.json` in the current directory and uses `jsii.tsconfig` and `jsii.validateTsconfig` as defaults — consistent with how the main compile command resolves these settings. The package.json read is skipped entirely when both values are explicitly provided on the CLI.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
