### PR TITLE
chore: route PR head ref through env var instead of inline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,10 +107,12 @@ jobs:
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
       - name: Push changes
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |-
           git add .
           git commit -s -m "chore: self-mutation"
-          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          git push origin "HEAD:$HEAD_REF"
   matrix-test:
     name: test (node ${{ matrix.node-version }})
     needs: build

--- a/projenrc/build-workflow.ts
+++ b/projenrc/build-workflow.ts
@@ -168,10 +168,13 @@ export class BuildWorkflow {
           },
           {
             name: 'Push changes',
+            env: {
+              HEAD_REF: '${{ github.event.pull_request.head.ref }}',
+            },
             run: [
               'git add .',
               'git commit -s -m "chore: self-mutation"',
-              'git push origin HEAD:${{ github.event.pull_request.head.ref }}',
+              'git push origin "HEAD:$HEAD_REF"',
             ].join('\n'),
           },
         ],

--- a/projenrc/build-workflow.ts
+++ b/projenrc/build-workflow.ts
@@ -171,11 +171,9 @@ export class BuildWorkflow {
             env: {
               HEAD_REF: '${{ github.event.pull_request.head.ref }}',
             },
-            run: [
-              'git add .',
-              'git commit -s -m "chore: self-mutation"',
-              'git push origin "HEAD:$HEAD_REF"',
-            ].join('\n'),
+            run: ['git add .', 'git commit -s -m "chore: self-mutation"', 'git push origin "HEAD:$HEAD_REF"'].join(
+              '\n',
+            ),
           },
         ],
       },


### PR DESCRIPTION
Referencing event context inline in a run: block substitutes the raw value into the script text, where the shell then interprets it as code. Routing values through env: passes them to the script as data instead, so their contents are never parsed as part of the command.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0