### PR TITLE
fix: emit metadata.tscRootDir relative to package root

### DIFF
--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -117,7 +117,14 @@ export class Assembler implements Emitter {
 
       // rootDir may be set explicitly or not. If not, inferRootDir replicates
       // tsc's behavior of using the longest prefix of all built source files.
-      this.tscRootDir = program.getCompilerOptions().rootDir ?? inferRootDir(program);
+      // rootDir might also be absolute (just like outDir), so we normalize it
+      // to be relative to the package root. Otherwise the absolute path leaks
+      // into the assembly's `metadata.tscRootDir`, which breaks the
+      // reproducibility/fingerprint check for downstream consumers.
+      this.tscRootDir = normalizeConfigPath(
+        projectInfo.projectRoot,
+        program.getCompilerOptions().rootDir ?? inferRootDir(program),
+      );
       if (this.tscRootDir != null) {
         mainFile = path.join(this.tscRootDir, mainFile);
       }

--- a/test/compiler.test.ts
+++ b/test/compiler.test.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, existsSync, mkdtempSync, rmSync, writeFileSync, readFileSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, isAbsolute, join } from 'node:path';
 import { loadAssemblyFromPath, SPEC_FILE_NAME, SPEC_FILE_NAME_COMPRESSED } from '@jsii/spec';
 import * as ts from 'typescript';
 import { compile, Lock } from './fixtures';
@@ -172,6 +172,47 @@ describe(Compiler, () => {
             tscRootDir: rootDir,
           }),
         );
+      } finally {
+        rmSync(sourceDir, { force: true, recursive: true });
+      }
+    });
+
+    test('absolute rootDir is emitted as a relative tscRootDir in the assembly', () => {
+      const outDir = 'jsii-outdir';
+      const rootDir = 'jsii-rootdir';
+      const sourceDir = mkdtempSync(join(tmpdir(), 'jsii-tmpdir'));
+      mkdirSync(join(sourceDir, rootDir), { recursive: true });
+
+      try {
+        writeFileSync(join(sourceDir, rootDir, 'index.ts'), 'export class MarkerA {}');
+        writeFileSync(join(sourceDir, rootDir, 'README.md'), '# Test Package');
+
+        const compiler = new Compiler({
+          projectInfo: {
+            ..._makeProjectInfo(sourceDir, join(outDir, 'index.d.ts')),
+            tsc: {
+              outDir,
+              // Pass an ABSOLUTE rootDir, as happens in real out-of-source
+              // builds. The assembly must still record it relative to the
+              // package root, otherwise the absolute (machine-specific) path
+              // leaks into `metadata.tscRootDir` and breaks the assembly
+              // fingerprint/reproducibility check for downstream consumers.
+              rootDir: join(sourceDir, rootDir),
+            },
+          },
+          failOnWarnings: true,
+          projectReferences: false,
+        });
+
+        compiler.emit();
+
+        const assembly = loadAssemblyFromPath(sourceDir);
+        expect(assembly.metadata).toEqual(
+          expect.objectContaining({
+            tscRootDir: rootDir,
+          }),
+        );
+        expect(isAbsolute(assembly.metadata!.tscRootDir as string)).toBe(false);
       } finally {
         rmSync(sourceDir, { force: true, recursive: true });
       }


### PR DESCRIPTION
## Problem

When an out-of-source build is configured (tsc `outDir` + `rootDir`), the assembler records `rootDir` into the emitted assembly as `metadata.tscRootDir`. However `rootDir` (whether set explicitly in `tsconfig`, or inferred by `inferRootDir()` from the program's source file names) can be an **absolute** path.

As a result, published `.jsii` assemblies end up containing a machine-specific absolute path, e.g.:

```json
"metadata": { "tscRootDir": "/home/runner/work/cdk8s-core/cdk8s-core/src" }
```

where it should simply be `"src"`. Because the path embeds the CI checkout directory, the external package-integrity / fingerprint check (which replicates the release build and diffs the assembly) fails, since the absolute path is not reproducible across build environments.

## Fix

Run `rootDir` through the same `normalizeConfigPath(projectRoot, ...)` helper that `outDir` already uses, so `tscRootDir` is emitted **relative** to the package root. `normalizeConfigPath` is a no-op for already-relative paths, so this is backwards compatible; it only rewrites absolute paths to be package-relative.

`src/assembler.ts` (~line 120):
```ts
this.tscRootDir = normalizeConfigPath(
  projectInfo.projectRoot,
  program.getCompilerOptions().rootDir ?? inferRootDir(program),
);
```

The subsequent `path.join(this.tscRootDir, mainFile)` / `path.resolve(projectInfo.projectRoot, mainFile)` logic is unaffected, since the value was only ever used relative to the project root anyway.

## Test

Added a unit test in `test/compiler.test.ts` that configures an **absolute** `rootDir` and asserts the emitted `metadata.tscRootDir` is the relative `"src"`-style value (and `path.isAbsolute(...)` is `false`). The pre-existing "rootDir is added to assembly" test (relative `rootDir`) continues to pass, confirming backwards compatibility.

## Validation

- `yarn compile` — green
- `yarn eslint` — green
- `yarn test` — the new + existing `tscRootDir` tests pass. 4 unrelated failures in `test/tsconfig/validate-tsconfig-cli.test.ts` were confirmed **pre-existing on clean `main`** (they fail identically without this change — the CLI subprocess returns empty stdout / status 1 in this sandbox environment) and are not caused by this change.

## Follow-up

Clearing the cdk8s integrity-validation alarms additionally requires:
1. A **jsii patch release** that includes this fix, and
2. A **cdk8s jsii bump** to consume that release and re-publish the affected packages with a relative `tscRootDir`.

Until those two steps land and the packages are re-published, the alarms will persist even after this fix merges.
