### PR TITLE
fix: deprecation warnings can get very repetitive

### DIFF
--- a/src/transforms/deprecation-warnings.ts
+++ b/src/transforms/deprecation-warnings.ts
@@ -426,9 +426,14 @@ function createWarningFunctionCall(
 
 function generateWarningsFile(projectRoot: string, validatorStatements: ts.Statement[]) {
   const functionText = `function ${WARNING_FUNCTION_NAME}(name, deprecationMessage) {
+  if (ALREADY_WARNED.has(name)) {
+    return;
+  }
+  ALREADY_WARNED.add(name);
+
   const deprecated = process.env.JSII_DEPRECATED;
   const deprecationMode = ['warn', 'fail', 'quiet'].includes(deprecated) ? deprecated : 'warn';
-  const message = \`\${name} is deprecated.\\n  \${deprecationMessage.trim()}\\n  This API will be removed in the next major release.\`;
+  const message = \`\${name} is deprecated, and will be removed in the next major release.\\n  \${deprecationMessage.trim()}\`;
   switch (deprecationMode) {
     case "fail":
       throw new ${DEPRECATION_ERROR}(message);
@@ -437,6 +442,8 @@ function generateWarningsFile(projectRoot: string, validatorStatements: ts.State
       break;
   }
 }
+
+const ALREADY_WARNED = new Set();
 
 function ${GET_PROPERTY_DESCRIPTOR}(obj, prop) {
   const descriptor = Object.getOwnPropertyDescriptor(obj, prop);

--- a/test/deprecation-warnings.test.ts
+++ b/test/deprecation-warnings.test.ts
@@ -789,7 +789,6 @@ describe('thrown exceptions have the expected stack trace', () => {
       { addDeprecationWarnings: true },
     );
 
-
     const mockWarn = jest.fn();
 
     runJsiiCode(compilation, 'warn', {
@@ -974,7 +973,11 @@ function extractFunction(contents: string, functionName: string): string {
   return contents.slice(startIndex, endIndex + 1);
 }
 
-function createVmContext(compilation: HelperCompilationResult, deprecationBehavior: 'fail' | 'warn' = 'fail', additionalContext: Record<string, unknown> = {}) {
+function createVmContext(
+  compilation: HelperCompilationResult,
+  deprecationBehavior: 'fail' | 'warn' = 'fail',
+  additionalContext: Record<string, unknown> = {},
+) {
   const context = vm.createContext({
     exports: {},
     process: {
@@ -1022,7 +1025,11 @@ function loadWarningsFile(projectRoot: string) {
   return fs.readFileSync(path.join(projectRoot, '.warnings.jsii.js')).toString();
 }
 
-function runJsiiCode(compilation: HelperCompilationResult, deprecationBehavior: 'fail' | 'warn' = 'fail', additionalContext: Record<string, unknown> = {}) {
+function runJsiiCode(
+  compilation: HelperCompilationResult,
+  deprecationBehavior: 'fail' | 'warn' = 'fail',
+  additionalContext: Record<string, unknown> = {},
+) {
   const source = jsFile(compilation);
   const context = createVmContext(compilation, deprecationBehavior, additionalContext);
   vm.runInContext(source, context, { filename: 'index.js' });

--- a/test/deprecation-warnings.test.ts
+++ b/test/deprecation-warnings.test.ts
@@ -9,6 +9,10 @@ import { compileJsiiForTest, HelperCompilationResult } from '../lib';
 
 const DEPRECATED = '/** @deprecated Use something else */';
 
+beforeEach(() => {
+  jest.restoreAllMocks();
+});
+
 describe('Function generation', () => {
   test('generates the print function', () => {
     const result = compileJsiiForTest('', undefined /* callback */, {
@@ -17,9 +21,13 @@ describe('Function generation', () => {
 
     expect(jsFile(result, '.warnings.jsii')).toContain(
       `function print(name, deprecationMessage) {
+    if (ALREADY_WARNED.has(name)) {
+        return;
+    }
+    ALREADY_WARNED.add(name);
     const deprecated = process.env.JSII_DEPRECATED;
     const deprecationMode = ["warn", "fail", "quiet"].includes(deprecated) ? deprecated : "warn";
-    const message = \`\${name} is deprecated.\\n  \${deprecationMessage.trim()}\\n  This API will be removed in the next major release.\`;
+    const message = \`\${name} is deprecated, and will be removed in the next major release.\\n  \${deprecationMessage.trim()}\`;
     switch (deprecationMode) {
         case "fail":
             throw new DeprecationError(message);
@@ -28,6 +36,7 @@ describe('Function generation', () => {
             break;
     }
 }
+const ALREADY_WARNED = new Set();
 function getPropertyDescriptor(obj, prop) {
     const descriptor = Object.getOwnPropertyDescriptor(obj, prop);
     if (descriptor) {
@@ -753,13 +762,43 @@ describe('thrown exceptions have the expected stack trace', () => {
                 throw error;
                 ^
 
-        DeprecationError: testpkg.DeprecatedConstructor is deprecated.
+        DeprecationError: testpkg.DeprecatedConstructor is deprecated, and will be removed in the next major release.
          for testing
-         This API will be removed in the next major release.
             at test (index.js:21:5)
             at index.js:23:1"
       `);
     }
+  });
+
+  test('multiple calls for the same element only get reported once', () => {
+    const compilation = compileJsiiForTest(
+      `
+      /** @deprecated for testing */
+      export class DeprecatedConstructor {
+        public constructor() {}
+      }
+
+      function test() {
+        new DeprecatedConstructor();
+      }
+
+      test();
+      test();
+    `,
+      undefined,
+      { addDeprecationWarnings: true },
+    );
+
+
+    const mockWarn = jest.fn();
+
+    runJsiiCode(compilation, 'warn', {
+      console: {
+        warn: mockWarn,
+      },
+    });
+
+    expect(mockWarn).toHaveBeenCalledTimes(1);
   });
 
   test('getter', () => {
@@ -795,9 +834,8 @@ describe('thrown exceptions have the expected stack trace', () => {
                     throw error;
                     ^
 
-        DeprecationError: testpkg.DeprecatedConstructor#property is deprecated.
+        DeprecationError: testpkg.DeprecatedConstructor#property is deprecated, and will be removed in the next major release.
          for testing
-         This API will be removed in the next major release.
             at test (index.js:25:20)
             at index.js:27:1"
       `);
@@ -843,9 +881,8 @@ describe('thrown exceptions have the expected stack trace', () => {
                     throw error;
                     ^
 
-        DeprecationError: testpkg.DeprecatedConstructor#property is deprecated.
+        DeprecationError: testpkg.DeprecatedConstructor#property is deprecated, and will be removed in the next major release.
          for testing
-         This API will be removed in the next major release.
             at test (index.js:38:22)
             at index.js:40:1"
       `);
@@ -885,9 +922,8 @@ describe('thrown exceptions have the expected stack trace', () => {
                     throw error;
                     ^
 
-        DeprecationError: testpkg.DeprecatedConstructor#deprecated is deprecated.
+        DeprecationError: testpkg.DeprecatedConstructor#deprecated is deprecated, and will be removed in the next major release.
          for testing
-         This API will be removed in the next major release.
             at test (index.js:24:13)
             at index.js:26:1"
       `);
@@ -938,12 +974,12 @@ function extractFunction(contents: string, functionName: string): string {
   return contents.slice(startIndex, endIndex + 1);
 }
 
-function createVmContext(compilation: HelperCompilationResult) {
+function createVmContext(compilation: HelperCompilationResult, deprecationBehavior: 'fail' | 'warn' = 'fail', additionalContext: Record<string, unknown> = {}) {
   const context = vm.createContext({
     exports: {},
     process: {
       env: {
-        JSII_DEPRECATED: 'fail',
+        JSII_DEPRECATED: deprecationBehavior,
       },
     },
     // Bringing in a "fake" require(id) function that'll resolve relative paths
@@ -971,6 +1007,7 @@ function createVmContext(compilation: HelperCompilationResult) {
         { filename: id, lineOffset: -2, columnOffset: -4 },
       );
     },
+    ...additionalContext,
   });
 
   // Limit error stack traces to 2 frames... We don't need more for the sake of this test. This is
@@ -983,4 +1020,10 @@ function createVmContext(compilation: HelperCompilationResult) {
 
 function loadWarningsFile(projectRoot: string) {
   return fs.readFileSync(path.join(projectRoot, '.warnings.jsii.js')).toString();
+}
+
+function runJsiiCode(compilation: HelperCompilationResult, deprecationBehavior: 'fail' | 'warn' = 'fail', additionalContext: Record<string, unknown> = {}) {
+  const source = jsFile(compilation);
+  const context = createVmContext(compilation, deprecationBehavior, additionalContext);
+  vm.runInContext(source, context, { filename: 'index.js' });
 }


### PR DESCRIPTION
If a method that gets called a lot is deprecated, the warnings get very repetitive. Writing to a terminal can noticeably slow down a program, and a lot of errors make logs unreadable.

It will suffice to warn once, so we add a deduplication mechanism: once we've already warned about an API we won't do it again.

Same for exceptions, but the exception should terminate the program so it shouldn't make a difference.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0